### PR TITLE
Update postgres_database.py

### DIFF
--- a/core/database/postgres_database.py
+++ b/core/database/postgres_database.py
@@ -631,11 +631,12 @@ class PostgresDatabase(BaseDatabase):
                     
                     # Set all attributes
                     for key, value in updates.items():
-                        if key == "storage_files" and isinstance(value, list):
-                            # Ensure storage_files items are serializable (convert StorageFileInfo to dict)
+                       if key == "storage_files" and isinstance(value, list):
                             serialized_value = [
-                                item.model_dump() if hasattr(item, "model_dump") else
-                                (item.dict() if hasattr(item, "dict") else item)
+                                _serialize_datetime(
+                                    item.model_dump() if hasattr(item, "model_dump") else
+                                    (item.dict() if hasattr(item, "dict") else item)
+                                )
                                 for item in value
                             ]
                             logger.debug(f"Serializing storage_files before setting attribute")


### PR DESCRIPTION
### Fix: Ensure datetime serialization in storage_files during document update

- Applied `_serialize_datetime() ` to each item in the storage_files list before updating the document model.
- This prevents TypeError: Object of type datetime is not JSON serializable when saving to the database.
- Handles cases where storage_files entries contain datetime fields inside Pydantic models or raw dicts.