### PR TITLE
Add rust install to dockerfile for orjson

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -14,6 +14,12 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Rust using the simpler method
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Copy requirements and install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir --user -r requirements.txt

--- a/dockerfile
+++ b/dockerfile
@@ -16,9 +16,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Rust using the simpler method
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy requirements and install dependencies
 COPY requirements.txt .


### PR DESCRIPTION
Looks like orjson needs rust/cargo installed.

```
Collecting orjson==3.10.3 (from -r requirements.txt (line 206))
     Downloading orjson-3.10.3.tar.gz (4.9 MB)
     Installing build dependencies: started
     Installing build dependencies: finished with status 'done'
     Getting requirements to build wheel: started
     Getting requirements to build wheel: finished with status 'done'
     Preparing metadata (pyproject.toml): started
     Preparing metadata (pyproject.toml): finished with status 'error'
     error: subprocess-exited-with-error
     
     × Preparing metadata (pyproject.toml) did not run successfully.
     │ exit code: 1
     ╰─> [6 lines of output]
         Checking for Rust toolchain....
         
         Cargo, the Rust package manager, is not installed or is not on PATH.
         This package requires Rust and Cargo to compile extensions. Install it through
         the system's package manager or via https://rustup.rs/
         
         [end of output]
     
     note: This error originates from a subprocess, and is likely not a problem with pip.
   error: metadata-generation-failed
```