### PR TITLE
Allow external_id to be set during ingestion

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -418,8 +418,11 @@ async def ingest_file(
 
         logger.debug(f"API: Queueing file ingestion with use_colpali: {use_colpali}")
 
+        external_id = metadata_dict.pop("external_id", None)
+
         # Create a document with processing status
         doc = Document(
+            external_id=external_id if external_id else None,  # Only pass if not None
             content_type=file.content_type,
             filename=file.filename,
             metadata=metadata_dict,


### PR DESCRIPTION
We have a need for our local DB's document IDs to match those in Morphik. 

This allows for a metadata `external_id` property to be set which overrides the default document UUID generator.