### PR TITLE
Fix: allow docker POSTGRES_URI to be loaded from env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "8000:8000"
     environment:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
-      - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
+      - POSTGRES_URI=${POSTGRES_URI:-postgresql+asyncpg://morphik:morphik@postgres:5432/morphik}
       - PGPASSWORD=morphik
       - HOST=0.0.0.0
       - PORT=8000
@@ -53,7 +53,7 @@ services:
     command: arq core.workers.ingestion_worker.WorkerSettings
     environment:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
-      - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
+      - POSTGRES_URI=${POSTGRES_URI:-postgresql+asyncpg://morphik:morphik@postgres:5432/morphik}
       - PGPASSWORD=morphik
       - LOG_LEVEL=DEBUG
       - REDIS_HOST=redis


### PR DESCRIPTION
Right now docker-compose always uses a local postgres connection. This lets you set a POSTGRES_URI in .env to specify alternate postgres location.