### PR TITLE
Add optional ability to configure Azure model using .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,14 @@ ASSEMBLYAI_API_KEY="..." # Optional: Needed for combined parser
 ANTHROPIC_API_KEY="..." # Optional: Needed for contextual parser
 AWS_ACCESS_KEY="..." # Optional: Needed for AWS S3 storage
 AWS_SECRET_ACCESS_KEY="..." # Optional: Needed for AWS S3 storage
+
+AZURE_MODEL_NAME="..."  # Optional: Used for Azure completion model name eg. "azure/gpt-4.1"
+AZURE_API_BASE="..."  # Optional: Azure API base URL eg. "https://xxxx.openai.azure.com"
+AZURE_API_KEY="..."  # Optional: Azure API key
+AZURE_DEPLOYMENT_ID="..."  # Optional: Azure deployment ID eg. "gpt-4.1"
+AZURE_API_VERSION="..."  # Optional: Azure API version eg. "2025-01-01-preview"
+AZURE_EMBEDDING_MODEL_NAME="..."  # Optional: Azure embedding model name eg. "azure/text-embedding-ada-002"
+AZURE_EMBEDDING_API_BASE="..."  # Optional: Azure embedding API base URL eg. "https://xxxx.openai.azure.com"
+AZURE_EMBEDDING_API_KEY="..."  # Optional: Azure embedding API key
+AZURE_EMBEDDING_DEPLOYMENT_ID="..."  # Optional: Azure embedding deployment ID eg. "text-embedding-ada-002"
+AZURE_EMBEDDING_API_VERSION="..."  # Optional: Azure embedding API version eg. "2024-02-01"

--- a/core/config.py
+++ b/core/config.py
@@ -1,7 +1,9 @@
+
 import os
+import re
 from collections import ChainMap
 from functools import lru_cache
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import tomli
 from dotenv import load_dotenv
@@ -137,6 +139,28 @@ def get_settings() -> Settings:
     """Get cached settings instance."""
     load_dotenv(override=True)
 
+        # Function to substitute environment variables in string values
+    def substitute_env_vars(value: Any) -> Any:
+
+        if isinstance(value, str):
+            env_var_pattern = r'\${([A-Za-z0-9_]+)}'
+            matches = re.findall(env_var_pattern, value)
+            if matches:
+                result = value
+                for var_name in matches:
+                    if var_name in os.environ:
+                        result = result.replace(f"${{{var_name}}}", os.environ[var_name])
+                    else:
+                        print(f"Warning: Environment variable '{var_name}' used in config but not found in environment")
+                return result
+            return value
+        elif isinstance(value, dict):
+            return {k: substitute_env_vars(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [substitute_env_vars(item) for item in value]
+        else:
+            return value
+    
     # Load config.toml
     with open("morphik.toml", "rb") as f:
         config = tomli.load(f)
@@ -168,7 +192,8 @@ def get_settings() -> Settings:
     # Load registered models if available
     registered_models = {}
     if "registered_models" in config:
-        registered_models = {"REGISTERED_MODELS": config["registered_models"]}
+        processed_models = substitute_env_vars(config["registered_models"])
+        registered_models = {"REGISTERED_MODELS": processed_models}
 
     # load completion config
     completion_config = {
@@ -178,10 +203,10 @@ def get_settings() -> Settings:
     # Set the model key for LiteLLM
     if "model" not in config["completion"]:
         raise ValueError("'model' is required in the completion configuration")
-    completion_config["COMPLETION_MODEL"] = config["completion"]["model"]
+    completion_config["COMPLETION_MODEL"] = substitute_env_vars(config["completion"]["model"])
 
     # load agent config
-    agent_config = {"AGENT_MODEL": config["agent"]["model"]}
+    agent_config = {"AGENT_MODEL": substitute_env_vars(config["agent"]["model"])}
     if "model" not in config["agent"]:
         raise ValueError("'model' is required in the agent configuration")
 
@@ -218,7 +243,7 @@ def get_settings() -> Settings:
     # Set the model key for LiteLLM
     if "model" not in config["embedding"]:
         raise ValueError("'model' is required in the embedding configuration")
-    embedding_config["EMBEDDING_MODEL"] = config["embedding"]["model"]
+    embedding_config["EMBEDDING_MODEL"] = substitute_env_vars(config["embedding"]["model"])
 
     # load parser config
     parser_config = {
@@ -290,7 +315,7 @@ def get_settings() -> Settings:
     # Set the model key for LiteLLM
     if "model" not in config["rules"]:
         raise ValueError("'model' is required in the rules configuration")
-    rules_config["RULES_MODEL"] = config["rules"]["model"]
+    rules_config["RULES_MODEL"] = substitute_env_vars(config["rules"]["model"])
 
     # load morphik config
     morphik_config = {
@@ -322,12 +347,12 @@ def get_settings() -> Settings:
     # Set the model key for LiteLLM
     if "model" not in config["graph"]:
         raise ValueError("'model' is required in the graph configuration")
-    graph_config["GRAPH_MODEL"] = config["graph"]["model"]
+    graph_config["GRAPH_MODEL"] = substitute_env_vars(config["graph"]["model"])
 
     # load document analysis config
     document_analysis_config = {}
     if "document_analysis" in config:
-        document_analysis_config = {"DOCUMENT_ANALYSIS_MODEL": config["document_analysis"]["model"]}
+        document_analysis_config = {"DOCUMENT_ANALYSIS_MODEL": substitute_env_vars(config["document_analysis"]["model"])}
 
     # load telemetry config
     telemetry_config = {}

--- a/morphik.toml
+++ b/morphik.toml
@@ -21,6 +21,7 @@ openai_gpt4o_mini = { model_name = "gpt-4o-mini" }
 # Azure OpenAI models
 azure_gpt4 = { model_name = "gpt-4", api_base = "YOUR_AZURE_URL_HERE", api_version = "2023-05-15", deployment_id = "gpt-4-deployment" }
 azure_gpt35 = { model_name = "gpt-3.5-turbo", api_base = "YOUR_AZURE_URL_HERE", api_version = "2023-05-15", deployment_id = "gpt-35-turbo-deployment" }
+azure_completion = { model_name = "${AZURE_MODEL_NAME}", api_base = "${AZURE_API_BASE}", api_key = "${AZURE_API_KEY}", api_version = "${AZURE_API_VERSION}", deployment_id = "${AZURE_DEPLOYMENT_ID}" } # Optionally configure using .env file
 
 # Anthropic models
 claude_opus = { model_name = "claude-3-opus-20240229" }
@@ -40,6 +41,7 @@ ollama_llama_vision_docker_docker = { model_name = "ollama_chat/llama3.2-vision"
 openai_embedding = { model_name = "text-embedding-3-small" }
 openai_embedding_large = { model_name = "text-embedding-3-large" }
 azure_embedding = { model_name = "text-embedding-ada-002", api_base = "YOUR_AZURE_URL_HERE", api_version = "2023-05-15", deployment_id = "embedding-ada-002" }
+# azure_embedding = { model_name = "${AZURE_EMBEDDING_MODEL_NAME}", api_base = "${AZURE_EMBEDDING_API_BASE}", api_key = "${AZURE_EMBEDDING_API_KEY}", api_version = "${AZURE_EMBEDDING_API_VERSION}", deployment_id = "${AZURE_EMBEDDING_DEPLOYMENT_ID}" } # Optionally configure using .env file
 ollama_embedding = { model_name = "ollama/nomic-embed-text", api_base = "http://localhost:11434" }
 # If you are running on docker, but running ollama locally use the following
 ollama_embedding_docker = { model_name = "ollama/nomic-embed-text", api_base = "http://host.docker.internal:11434" }


### PR DESCRIPTION
Current implmentation of Azure completion and embedding models require hard coding the configuration including API Key in the morphik.toml file.

This change allows the ability to retain current method for backward compatibilty, but also allows the option to configure all the parameters via the .env
