### PR TITLE
fix docker worker service error

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -157,6 +157,7 @@ fi\n\
 
 # Copy application code
 COPY core ./core
+COPY ee ./ee
 COPY README.md LICENSE ./
 
 # Labels for the image


### PR DESCRIPTION
Docker worker service fails with ModuleNotFoundError: No module named 'ee'
added ee folder to dockerfile