### PR TITLE
feat: add batch delete documents support to API, SDK, CLI, and tests

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -35,6 +35,7 @@ from core.models.graph import Graph
 from core.models.prompts import validate_prompt_overrides_with_http_exception
 from core.models.request import (
     AgentQueryRequest,
+    BatchDeleteRequest,
     BatchIngestResponse,
     CompletionQueryRequest,
     CreateGraphRequest,
@@ -1058,6 +1059,27 @@ async def delete_document(document_id: str, auth: AuthContext = Depends(verify_t
         raise HTTPException(status_code=403, detail=str(e))
 
 
+@app.post("/documents/batch_delete")
+@telemetry.track(operation_type="batch_delete_documents", metadata_resolver=telemetry.document_delete_metadata)
+async def batch_delete_documents(request: BatchDeleteRequest, auth: AuthContext = Depends(verify_token)):
+    """
+    Batch delete documents by their IDs.
+
+    Args:
+        request: List of document IDs in JSON.
+        auth: AuthContext
+
+    Returns:
+        Dict: Status and count of deleted documents
+    """
+    try:
+        deleted_count = await document_service.delete_documents(request.document_ids, auth)
+        return {"status": "success", "deleted": deleted_count, "requested": len(request.document_ids)}
+    except Exception as e:
+        logger.error(f"Batch deletion failed: {e}")
+        raise HTTPException(status_code=500, detail="Batch deletion failed")
+
+
 @app.get("/documents/filename/{filename}", response_model=Document)
 async def get_document_by_filename(
     filename: str,
@@ -2050,8 +2072,7 @@ async def set_folder_rule(
                                     except Exception as rule_apply_error:
                                         last_error = rule_apply_error
                                         logger.warning(
-                                            f"Metadata extraction attempt {retry_count + 1} failed: "
-                                            f"{rule_apply_error}"
+                                            f"Metadata extraction attempt {retry_count + 1} failed: {rule_apply_error}"
                                         )
                                         if retry_count == max_retries - 1:  # Last attempt
                                             logger.error(f"All {max_retries} metadata extraction attempts failed")

--- a/core/models/request.py
+++ b/core/models/request.py
@@ -143,3 +143,12 @@ class AgentQueryRequest(BaseModel):
     """Request model for agent queries"""
 
     query: str = Field(..., description="Natural language query for the Morphik agent")
+
+
+class BatchDeleteRequest(BaseModel):
+    """Request model for delete batch documents"""
+
+    document_ids: List[str] = Field(
+        ...,
+        description="List of document IDs to be deleted. Must be a list of strings.",
+    )

--- a/core/services/document_service.py
+++ b/core/services/document_service.py
@@ -244,7 +244,7 @@ class DocumentService:
             chunks = await self.reranker.rerank(query, chunks)
             chunks.sort(key=lambda x: x.score, reverse=True)
             chunks = chunks[:k]
-            logger.debug(f"Reranked {k*10} chunks and selected the top {k}")
+            logger.debug(f"Reranked {k * 10} chunks and selected the top {k}")
 
         # Combine multiple chunk sources if needed
         chunks = await self._combine_multi_and_regular_chunks(
@@ -852,7 +852,7 @@ class DocumentService:
         if folder_name:
             try:
                 await self._ensure_folder_exists(folder_name, doc.external_id, auth)
-                logger.debug(f"Ensured folder '{folder_name}' exists " f"and contains document {doc.external_id}")
+                logger.debug(f"Ensured folder '{folder_name}' exists and contains document {doc.external_id}")
             except Exception as e:
                 logger.error(
                     f"Error during _ensure_folder_exists for doc {doc.external_id}"
@@ -1210,7 +1210,7 @@ class DocumentService:
                             current_retry_delay *= 2
                         else:
                             logger.error(
-                                f"All database connection attempts failed " f"after {max_retries} retries: {error_msg}"
+                                f"All database connection attempts failed after {max_retries} retries: {error_msg}"
                             )
                             raise Exception("Failed to store document metadata after multiple retries")
                     else:
@@ -2035,6 +2035,27 @@ class DocumentService:
             entry["metadata_updated"] = True
 
         history.append(entry)
+
+    async def delete_documents(self, document_ids: List[str], auth: AuthContext) -> int:
+        """
+        Batch delete documents and their associated data.
+
+        Args:
+            document_ids: List of document IDs to delete.
+            auth: Authentication context.
+
+        Returns:
+            int: Number of documents successfully deleted.
+        """
+        deleted = 0
+        for doc_id in document_ids:
+            try:
+                success = await self.delete_document(doc_id, auth)
+                if success:
+                    deleted += 1
+            except Exception as e:
+                logger.warning(f"Failed to delete document {doc_id}: {e}")
+        return deleted
 
     # ------------------------------------------------------------------
     # Helper – choose bucket per app (isolation)

--- a/sdks/python/morphik/async_.py
+++ b/sdks/python/morphik/async_.py
@@ -2540,3 +2540,8 @@ class AsyncMorphik:
                 raise RuntimeError(graph.error or "Graph processing failed")
             await asyncio.sleep(check_interval_seconds)
         raise TimeoutError("Timed out waiting for graph completion")
+
+    async def batch_delete_documents(self, document_ids: List[str]) -> int:
+        """Delete multiple documents by their IDs (async)."""
+        response = await self._request("POST", "documents/batch_delete", data={"document_ids": document_ids})
+        return response["deleted"]

--- a/sdks/python/morphik/sync.py
+++ b/sdks/python/morphik/sync.py
@@ -2735,3 +2735,8 @@ class Morphik:
                 raise RuntimeError(graph.error or "Graph processing failed")
             time.sleep(check_interval_seconds)
         raise TimeoutError("Timed out waiting for graph completion")
+
+    def batch_delete_documents(self, document_ids: List[str]) -> int:
+        """Delete multiple documents by their IDs."""
+        response = self._request("POST", "documents/batch_delete", data={"document_ids": document_ids})
+        return response["deleted"]

--- a/sdks/python/morphik/tests/test_async.py
+++ b/sdks/python/morphik/tests/test_async.py
@@ -382,3 +382,27 @@ class TestAsyncMorphik:
 
         finally:
             await db.delete_document(doc.external_id)
+
+    @pytest.mark.asyncio
+    async def test_batch_delete_documents(self, db):
+        """Test batch deleting multiple documents"""
+        # Given
+        doc1 = await db.ingest_text(
+            content="This is batch delete document 1",
+            filename=f"batch_del_1_{uuid.uuid4().hex[:6]}.txt",
+            metadata={"test_case": "batch_delete"},
+        )
+        doc2 = await db.ingest_text(
+            content="This is batch delete document 2",
+            filename=f"batch_del_2_{uuid.uuid4().hex[:6]}.txt",
+            metadata={"test_case": "batch_delete"},
+        )
+
+        # Then
+        assert doc1.external_id and doc2.external_id
+
+        # When
+        deleted_count = await db.batch_delete_documents([doc1.external_id, doc2.external_id])
+
+        # Then
+        assert deleted_count == 2

--- a/sdks/python/morphik/tests/test_sync.py
+++ b/sdks/python/morphik/tests/test_sync.py
@@ -369,3 +369,27 @@ class TestMorphik:
 
         finally:
             db.delete_document(doc.external_id)
+
+    def test_batch_delete_documents(self, db):
+        """Test batch deleting multiple documents (sync)"""
+        # Given
+        doc1 = db.ingest_text(
+            content="First document to test batch delete",
+            filename=f"batch_delete_1_{uuid.uuid4().hex[:6]}.txt",
+            metadata={"test_id": "sync_batch_delete_test"},
+        )
+        doc2 = db.ingest_text(
+            content="Second document to test batch delete",
+            filename=f"batch_delete_2_{uuid.uuid4().hex[:6]}.txt",
+            metadata={"test_id": "sync_batch_delete_test"},
+        )
+
+        # Then
+        assert doc1.external_id is not None
+        assert doc2.external_id is not None
+
+        # When
+        deleted = db.batch_delete_documents([doc1.external_id, doc2.external_id])
+
+        # Then
+        assert deleted == 2


### PR DESCRIPTION
- Added /documents/batch_delete API endpoint for deleting multiple documents at once
- Implemented service method to handle deletion and error resilience
- Updated SDK (sync + async) to expose batch_delete_documents()
- Added CLI command: `morphik batch-delete <doc_ids...>`
- Added test cases in both async and sync SDKs to verify batch deletion