### PR TITLE
fix dockerfile 'as' casing

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM python:3.11.12-slim as builder
+FROM python:3.11.12-slim AS builder
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/


### PR DESCRIPTION
There's a docker build issue around the `as` casing.

```
#26 [stage-1  4/15] COPY --from=builder /app/.venv /app/.venv
#26 ERROR: failed to copy files: copy file range failed: no space left on device
------
 > [stage-1  4/15] COPY --from=builder /app/.venv /app/.venv:
------
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
dockerfile:85
```