### PR TITLE
Add chat persistence

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -38,6 +38,7 @@ from core.models.request import (
     SetFolderRuleRequest,
     UpdateGraphRequest,
 )
+from core.models.chat import ChatMessage
 from core.services.telemetry import TelemetryService
 from core.services_init import document_service, storage
 
@@ -745,7 +746,11 @@ async def batch_get_chunks(request: Dict[str, Any], auth: AuthContext = Depends(
 
 @app.post("/query", response_model=CompletionResponse)
 @telemetry.track(operation_type="query", metadata_resolver=telemetry.query_metadata)
-async def query_completion(request: CompletionQueryRequest, auth: AuthContext = Depends(verify_token)):
+async def query_completion(
+    request: CompletionQueryRequest,
+    auth: AuthContext = Depends(verify_token),
+    redis: arq.ArqRedis = Depends(get_redis_pool),
+):
     """
     Generate completion using relevant chunks as context.
 
@@ -777,14 +782,41 @@ async def query_completion(request: CompletionQueryRequest, auth: AuthContext = 
     try:
         # Validate prompt overrides before proceeding
         if request.prompt_overrides:
-            validate_prompt_overrides_with_http_exception(request.prompt_overrides, operation_type="query")
+            validate_prompt_overrides_with_http_exception(
+                request.prompt_overrides, operation_type="query"
+            )
+
+        history_key = None
+        history: List[Dict[str, Any]] = []
+        if request.chat_id:
+            history_key = f"chat:{request.chat_id}"
+            stored = await redis.get(history_key)
+            if stored:
+                try:
+                    history = json.loads(stored)
+                except Exception:
+                    history = []
+            else:
+                db_hist = await document_service.db.get_chat_history(
+                    request.chat_id, auth.user_id, auth.app_id
+                )
+                if db_hist:
+                    history = db_hist
+
+            history.append(
+                {
+                    "role": "user",
+                    "content": request.query,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+            )
 
         # Check query limits if in cloud mode
         if settings.MODE == "cloud" and auth.user_id:
             # Check limits before proceeding
             await check_and_increment_limits(auth, "query", 1)
 
-        return await document_service.query(
+        response = await document_service.query(
             request.query,
             auth,
             request.filters,
@@ -801,11 +833,51 @@ async def query_completion(request: CompletionQueryRequest, auth: AuthContext = 
             request.folder_name,
             request.end_user_id,
             request.schema,
+            history,
         )
+
+        if history_key:
+            history.append(
+                {
+                    "role": "assistant",
+                    "content": response.completion,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+            )
+            await redis.set(history_key, json.dumps(history))
+            await document_service.db.upsert_chat_history(
+                request.chat_id,
+                auth.user_id,
+                auth.app_id,
+                history,
+            )
+
+        return response
     except ValueError as e:
         validate_prompt_overrides_with_http_exception(operation_type="query", error=e)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
+
+
+@app.get("/chat/{chat_id}", response_model=List[ChatMessage])
+async def get_chat_history(
+    chat_id: str,
+    auth: AuthContext = Depends(verify_token),
+    redis: arq.ArqRedis = Depends(get_redis_pool),
+):
+    """Return stored chat history for *chat_id* if available."""
+    history_key = f"chat:{chat_id}"
+    stored = await redis.get(history_key)
+    if not stored:
+        db_hist = await document_service.db.get_chat_history(chat_id, auth.user_id, auth.app_id)
+        if not db_hist:
+            return []
+        return [ChatMessage(**m) for m in db_hist]
+    try:
+        data = json.loads(stored)
+        return [ChatMessage(**m) for m in data]
+    except Exception:
+        return []
 
 
 @app.post("/agent", response_model=Dict[str, Any])

--- a/core/completion/litellm_completion.py
+++ b/core/completion/litellm_completion.py
@@ -204,6 +204,7 @@ class LiteLLMCompletionModel(BaseCompletionModel):
         user_content: str,
         ollama_image_data: List[str],
         request: CompletionRequest,
+        history_messages: List[Dict[str, str]],
     ) -> CompletionResponse:
         """Handle structured output generation with Ollama."""
         try:
@@ -216,7 +217,7 @@ class LiteLLMCompletionModel(BaseCompletionModel):
                 content_data = {"content": user_content, "images": [ollama_image_data[0]]}
 
             # Create messages for Ollama
-            messages = [system_message, {"role": "user", "content": content_data}]
+            messages = [system_message] + history_messages + [{"role": "user", "content": content_data}]
 
             # Get the JSON schema from the dynamic model
             format_schema = dynamic_model.model_json_schema()
@@ -261,6 +262,7 @@ class LiteLLMCompletionModel(BaseCompletionModel):
         user_content: str,
         image_urls: List[str],
         request: CompletionRequest,
+        history_messages: List[Dict[str, str]],
     ) -> CompletionResponse:
         """Handle structured output generation with LiteLLM."""
         import instructor
@@ -280,7 +282,7 @@ class LiteLLMCompletionModel(BaseCompletionModel):
                     content_list.append({"type": "image_url", "image_url": {"url": img_url}})
 
             # Create messages for instructor
-            messages = [system_message, {"role": "user", "content": content_list}]
+            messages = [system_message] + history_messages + [{"role": "user", "content": content_list}]
 
             # Extract model configuration
             model = self.model_config.get("model_name")
@@ -324,7 +326,11 @@ class LiteLLMCompletionModel(BaseCompletionModel):
             return None
 
     async def _handle_standard_ollama(
-        self, user_content: str, ollama_image_data: List[str], request: CompletionRequest
+        self,
+        user_content: str,
+        ollama_image_data: List[str],
+        request: CompletionRequest,
+        history_messages: List[Dict[str, str]],
     ) -> CompletionResponse:
         """Handle standard (non-structured) output generation with Ollama."""
         logger.debug(f"Using direct Ollama client for model: {self.ollama_base_model_name}")
@@ -344,7 +350,7 @@ class LiteLLMCompletionModel(BaseCompletionModel):
             # Add 'images' key inside the user message dictionary
             user_message_data["images"] = [ollama_image_data[0]]
 
-        ollama_messages = [system_message, user_message_data]
+        ollama_messages = [system_message] + history_messages + [user_message_data]
 
         # Construct Ollama options
         options = {
@@ -376,7 +382,11 @@ class LiteLLMCompletionModel(BaseCompletionModel):
             raise
 
     async def _handle_standard_litellm(
-        self, user_content: str, image_urls: List[str], request: CompletionRequest
+        self,
+        user_content: str,
+        image_urls: List[str],
+        request: CompletionRequest,
+        history_messages: List[Dict[str, str]],
     ) -> CompletionResponse:
         """Handle standard (non-structured) output generation with LiteLLM."""
         logger.debug(f"Using LiteLLM for model: {self.model_config['model_name']}")
@@ -392,7 +402,7 @@ class LiteLLMCompletionModel(BaseCompletionModel):
         # LiteLLM uses list content format
         user_message = {"role": "user", "content": content_list}
         # Use the system prompt defined earlier
-        litellm_messages = [get_system_message(), user_message]
+        litellm_messages = [get_system_message()] + history_messages + [user_message]
 
         # Prepare LiteLLM parameters
         model_params = {
@@ -436,6 +446,10 @@ class LiteLLMCompletionModel(BaseCompletionModel):
         # Format user content
         user_content = format_user_content(context_text, request.query, request.prompt_template)
 
+        history_messages = [
+            {"role": m.role, "content": m.content} for m in (request.chat_history or [])
+        ]
+
         # Check if structured output is requested
         structured_output = request.schema is not None
 
@@ -466,14 +480,24 @@ class LiteLLMCompletionModel(BaseCompletionModel):
                 # Try structured output based on model type
                 if self.is_ollama:
                     response = await self._handle_structured_ollama(
-                        dynamic_model, system_message, enhanced_user_content, ollama_image_data, request
+                        dynamic_model,
+                        system_message,
+                        enhanced_user_content,
+                        ollama_image_data,
+                        request,
+                        history_messages,
                     )
                     if response:
                         return response
                     structured_output = False  # Fall back if structured output failed
                 else:
                     response = await self._handle_structured_litellm(
-                        dynamic_model, system_message, enhanced_user_content, image_urls, request
+                        dynamic_model,
+                        system_message,
+                        enhanced_user_content,
+                        image_urls,
+                        request,
+                        history_messages,
                     )
                     if response:
                         return response
@@ -482,6 +506,10 @@ class LiteLLMCompletionModel(BaseCompletionModel):
         # If we're here, either structured output wasn't requested or instructor failed
         # Proceed with standard completion based on model type
         if self.is_ollama:
-            return await self._handle_standard_ollama(user_content, ollama_image_data, request)
+            return await self._handle_standard_ollama(
+                user_content, ollama_image_data, request, history_messages
+            )
         else:
-            return await self._handle_standard_litellm(user_content, image_urls, request)
+            return await self._handle_standard_litellm(
+                user_content, image_urls, request, history_messages
+            )

--- a/core/models/chat.py
+++ b/core/models/chat.py
@@ -1,0 +1,23 @@
+from datetime import UTC, datetime
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChatMessage(BaseModel):
+    """Simple chat message model for chat persistence."""
+
+    role: Literal["user", "assistant"]
+    content: str
+    timestamp: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+class ChatConversation(BaseModel):
+    """Conversation container persisted in the database."""
+
+    conversation_id: str
+    user_id: Optional[str] = None
+    app_id: Optional[str] = None
+    history: List[ChatMessage] = Field(default_factory=list)
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())

--- a/core/models/completion.py
+++ b/core/models/completion.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
+from .chat import ChatMessage
+
 from pydantic import BaseModel
 
 # Type variable for any Pydantic model
@@ -35,3 +37,4 @@ class CompletionRequest(BaseModel):
     folder_name: Optional[str] = None
     end_user_id: Optional[str] = None
     schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None
+    chat_history: Optional[List[ChatMessage]] = None

--- a/core/models/request.py
+++ b/core/models/request.py
@@ -40,6 +40,10 @@ class CompletionQueryRequest(RetrieveRequest):
         None,
         description="Schema for structured output, can be a Pydantic model or JSON schema dict",
     )
+    chat_id: Optional[str] = Field(
+        None,
+        description="Optional chat session ID for persisting conversation history",
+    )
 
 
 class IngestTextRequest(BaseModel):

--- a/core/services/document_service.py
+++ b/core/services/document_service.py
@@ -31,6 +31,7 @@ from core.models.chunk import Chunk, DocumentChunk
 from core.models.completion import ChunkSource, CompletionRequest, CompletionResponse
 from core.models.documents import ChunkResult, Document, DocumentContent, DocumentResult, StorageFileInfo
 from core.models.prompts import GraphPromptOverrides, QueryPromptOverrides
+from core.models.chat import ChatMessage
 from core.parser.base_parser import BaseParser
 from core.reranker.base_reranker import BaseReranker
 from core.services.graph_service import GraphService
@@ -493,6 +494,7 @@ class DocumentService:
         folder_name: Optional[Union[str, List[str]]] = None,
         end_user_id: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
+        chat_history: Optional[List[ChatMessage]] = None,
     ) -> CompletionResponse:
         """Generate completion using relevant chunks as context.
 
@@ -565,6 +567,7 @@ class DocumentService:
             temperature=temperature,
             prompt_template=custom_prompt_template,
             schema=schema,
+            chat_history=chat_history,
         )
 
         response = await self.completion_model.complete(request)

--- a/core/tests/integration/test_api.py
+++ b/core/tests/integration/test_api.py
@@ -184,6 +184,11 @@ async def cleanup_documents():
             except Exception as e:
                 logger.info(f"No chunks table to clean or error: {e}")
 
+            try:
+                await conn.execute(text("DELETE FROM chat_conversations"))
+            except Exception:
+                logger.info("No chat_conversations table to clean")
+
     except Exception as e:
         logger.error(f"Failed to clean up document tables: {e}")
         raise
@@ -3729,3 +3734,33 @@ async def test_ingest_empty_file_sets_failed_status(client: AsyncClient):
 
     assert status_info["status"] == "failed"
     assert "error" in status_info and "No content chunks" in status_info["error"]
+
+
+@pytest.mark.asyncio
+async def test_chat_persistence(client: AsyncClient):
+    """Ensure chat history is persisted across queries."""
+    headers = create_auth_header()
+    chat_id = str(uuid.uuid4())
+
+    await test_ingest_text_document(client, content="Chat persistence doc")
+
+    resp1 = await client.post(
+        "/query",
+        json={"query": "first", "chat_id": chat_id},
+        headers=headers,
+    )
+    assert resp1.status_code == 200
+
+    resp2 = await client.post(
+        "/query",
+        json={"query": "second", "chat_id": chat_id},
+        headers=headers,
+    )
+    assert resp2.status_code == 200
+
+    hist = await client.get(f"/chat/{chat_id}", headers=headers)
+    assert hist.status_code == 200
+    history = hist.json()
+    assert len(history) >= 4
+    assert history[0]["role"] == "user"
+    assert history[1]["role"] == "assistant"

--- a/ee/ui-component/components/types.ts
+++ b/ee/ui-component/components/types.ts
@@ -95,5 +95,6 @@ export interface Source {
 export interface ChatMessage {
   role: "user" | "assistant";
   content: string;
+  timestamp?: string;
   sources?: Source[];
 }

--- a/sdks/python/morphik/_internal.py
+++ b/sdks/python/morphik/_internal.py
@@ -251,6 +251,7 @@ class _MorphikClientLogic:
         prompt_overrides: Optional[Dict],
         folder_name: Optional[Union[str, List[str]]],
         end_user_id: Optional[str],
+        chat_id: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """Prepare request for query endpoint"""
@@ -271,6 +272,8 @@ class _MorphikClientLogic:
             payload["folder_name"] = folder_name
         if end_user_id:
             payload["end_user_id"] = end_user_id
+        if chat_id:
+            payload["chat_id"] = chat_id
 
         # Add schema to payload if provided
         if schema:

--- a/sdks/python/morphik/async_.py
+++ b/sdks/python/morphik/async_.py
@@ -391,6 +391,7 @@ class AsyncFolder:
             prompt_overrides,
             effective_folder,
             None,
+            chat_id,
             schema,
         )
 
@@ -925,6 +926,7 @@ class AsyncUserScope:
             prompt_overrides,
             effective_folder,
             self._end_user_id,
+            chat_id,
             schema,
         )
 
@@ -1549,6 +1551,7 @@ class AsyncMorphik:
         include_paths: bool = False,
         prompt_overrides: Optional[Union[QueryPromptOverrides, Dict[str, Any]]] = None,
         folder_name: Optional[Union[str, List[str]]] = None,
+        chat_id: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
     ) -> CompletionResponse:
         """
@@ -1654,6 +1657,7 @@ class AsyncMorphik:
             prompt_overrides,
             effective_folder,
             None,
+            chat_id,
             schema,
         )
 

--- a/sdks/python/morphik/sync.py
+++ b/sdks/python/morphik/sync.py
@@ -404,6 +404,7 @@ class Folder:
             prompt_overrides,
             effective_folder,
             None,  # end_user_id not supported at this level
+            chat_id,
             schema,
         )
 
@@ -985,6 +986,7 @@ class UserScope:
             prompt_overrides,
             effective_folder,
             self._end_user_id,
+            chat_id,
             schema,
         )
 
@@ -1692,6 +1694,7 @@ class Morphik:
         include_paths: bool = False,
         prompt_overrides: Optional[Union[QueryPromptOverrides, Dict[str, Any]]] = None,
         folder_name: Optional[Union[str, List[str]]] = None,
+        chat_id: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
     ) -> CompletionResponse:
         """
@@ -1798,6 +1801,7 @@ class Morphik:
             prompt_overrides,
             folder_name,
             None,  # end_user_id not supported at this level
+            chat_id,
             schema,
         )
 


### PR DESCRIPTION
## Summary
- add ChatConversation model and DB table
- persist chat history in PostgreSQL and include past messages in completion requests
- fetch chat history from DB when Redis cache misses
- update completion engine to handle conversation context
- extend integration cleanup for chat history table

## Testing
- `pytest core/tests/integration/test_api.py::test_chat_persistence -q` *(fails: pytest not installed)*