### PR TITLE
Fix AttributeError when telemetry is disabled (#176)

### DIFF
--- a/core/services/telemetry.py
+++ b/core/services/telemetry.py
@@ -450,6 +450,9 @@ class TelemetryService:
         return cls._instance
 
     def _initialize(self):
+        # Initialize metadata extractors
+        self._setup_metadata_extractors()
+
         if not TELEMETRY_ENABLED:
             return
 
@@ -549,9 +552,6 @@ class TelemetryService:
             description="Duration of operations",
             unit="ms",
         )
-
-        # Initialize metadata extractors
-        self._setup_metadata_extractors()
 
     def _setup_metadata_extractors(self):
         """Set up all the metadata extractors with their field definitions."""


### PR DESCRIPTION
## Summary

Fixes #176

This PR ensures that metadata extractors are initialized even when telemetry is disabled. Previously, the `_initialize()` method returned early before setting up `ingest_file_metadata` and other attributes, leading to `AttributeError`.

## Changes

- Moved `_setup_metadata_extractors()` to run unconditionally before the `TELEMETRY_ENABLED` check.

## Testing

- Verified that the application runs correctly with both telemetry enabled and disabled.
- Confirmed that `AttributeError` no longer occurs when telemetry is disabled.

Let me know if you'd like any changes!