### PR TITLE
Add Gemini api key setting in .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ ASSEMBLYAI_API_KEY="..." # Optional: Needed for combined parser
 ANTHROPIC_API_KEY="..." # Optional: Needed for contextual parser
 AWS_ACCESS_KEY="..." # Optional: Needed for AWS S3 storage
 AWS_SECRET_ACCESS_KEY="..." # Optional: Needed for AWS S3 storage
+GEMINI_API_KEY="..." # Optional: Needed for Google Gemini models


### PR DESCRIPTION
# Summary
Added the GEMINI_API_KEY setting to the .env.example file.

# Description  
In the config.py file, there is a GEMINI_API_KEY field in the Settings class, but the .env.example file does not include a configuration entry for GEMINI_API_KEY.  

config.py file
![image](https://github.com/user-attachments/assets/ecb808ce-7e4e-4687-92c0-f86ca8a8f33c)  
  
.env.example file
![image](https://github.com/user-attachments/assets/33ee012d-473b-4e11-a347-a24f51e90a33)
  
So, I added the GEMINI_API_KEY setting.
![image](https://github.com/user-attachments/assets/b855ea4c-d0e3-4f20-b925-e390ae55eb29)
