### PR TITLE
Fix hardcoded localhost API URLs to use dynamic hostname

### DIFF
--- a/ee/ui-component/README.md
+++ b/ee/ui-component/README.md
@@ -35,7 +35,7 @@ export default function YourApp() {
 | Prop            | Type                    | Default                   | Description                            |
 | --------------- | ----------------------- | ------------------------- | -------------------------------------- |
 | `connectionUri` | `string`                | `undefined`               | Connection URI for Morphik API         |
-| `apiBaseUrl`    | `string`                | `"http://localhost:8000"` | Base URL for API requests              |
+| `apiBaseUrl`    | `string`                | `"http://{hostname}:8000"` | Base URL for API requests (defaults to current hostname) |
 | `isReadOnlyUri` | `boolean`               | `false`                   | Controls whether the URI can be edited |
 | `onUriChange`   | `(uri: string) => void` | `undefined`               | Callback when URI is changed           |
 

--- a/ee/ui-component/components/MorphikUI.tsx
+++ b/ee/ui-component/components/MorphikUI.tsx
@@ -31,7 +31,9 @@ import { useRouter, usePathname } from "next/navigation";
 const MorphikUI: React.FC<MorphikUIProps> = props => {
   const {
     connectionUri,
-    apiBaseUrl = "http://localhost:8000",
+    apiBaseUrl = typeof window !== 'undefined' 
+      ? `${window.location.protocol}//${window.location.hostname}:8000`
+      : "http://localhost:8000",
     initialSection = "documents",
     initialFolder = null,
     onBackClick,

--- a/ee/ui-component/components/pdf/PDFViewer.tsx
+++ b/ee/ui-component/components/pdf/PDFViewer.tsx
@@ -193,7 +193,9 @@ export function PDFViewer({ apiBaseUrl, authToken, initialDocumentId, onChatTogg
 
   // Use the new PDF chat sessions hook
   const { currentChatId, createNewSession } = usePDFChatSessions({
-    apiBaseUrl: apiBaseUrl || process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000",
+    apiBaseUrl: apiBaseUrl || process.env.NEXT_PUBLIC_API_BASE_URL || (typeof window !== 'undefined' 
+      ? `${window.location.protocol}//${window.location.hostname}:8000`
+      : "http://localhost:8000"),
     authToken: authToken || null,
     documentName: pdfState.documentId || pdfState.documentName || pdfState.file?.name,
   });
@@ -304,7 +306,9 @@ export function PDFViewer({ apiBaseUrl, authToken, initialDocumentId, onChatTogg
 
       // Make API call to our document chat endpoint
       const response = await fetch(
-        `${apiBaseUrl || process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000"}/document/chat/${chatId}/complete`,
+        `${apiBaseUrl || process.env.NEXT_PUBLIC_API_BASE_URL || (typeof window !== 'undefined' 
+          ? `${window.location.protocol}//${window.location.hostname}:8000`
+          : "http://localhost:8000")}/document/chat/${chatId}/complete`,
         {
           method: "POST",
           headers: {

--- a/ee/ui-component/contexts/morphik-context.tsx
+++ b/ee/ui-component/contexts/morphik-context.tsx
@@ -3,7 +3,9 @@
 import React, { createContext, useContext, useState } from "react";
 import { extractTokenFromUri, getApiBaseUrlFromUri } from "@/lib/utils";
 
-const DEFAULT_API_BASE_URL = "http://localhost:8000";
+const DEFAULT_API_BASE_URL = typeof window !== 'undefined' 
+  ? `${window.location.protocol}//${window.location.hostname}:8000`
+  : "http://localhost:8000";
 
 interface MorphikContextType {
   connectionUri: string | null;

--- a/ee/ui-component/lib/utils.ts
+++ b/ee/ui-component/lib/utils.ts
@@ -55,7 +55,9 @@ export function extractTokenFromUri(uri: string | undefined): string | null {
  * @param defaultUrl - The default API URL to use if URI is invalid
  * @returns The API base URL derived from the URI host
  */
-export function getApiBaseUrlFromUri(uri: string | undefined, defaultUrl: string = "http://localhost:8000"): string {
+export function getApiBaseUrlFromUri(uri: string | undefined, defaultUrl: string = typeof window !== 'undefined' 
+  ? `${window.location.protocol}//${window.location.hostname}:8000`
+  : "http://localhost:8000"): string {
   // If URI is empty or undefined, connect to the default URL
   if (!uri || uri.trim() === "") {
     return defaultUrl;


### PR DESCRIPTION

  ## Summary
  - Fixes hardcoded `localhost:8000` API URLs that caused upload failures in self-hosted environments
  - Implements dynamic hostname detection to automatically use the browser's current hostname
  - Maintains backward compatibility with localhost development setups

  ## Changes Made
  - **`contexts/morphik-context.tsx`**: Dynamic default API base URL
  - **`components/MorphikUI.tsx`**: Dynamic apiBaseUrl prop default
  - **`components/pdf/PDFViewer.tsx`**: Dynamic API endpoints for PDF chat (2 locations)
  - **`lib/utils.ts`**: Dynamic default in getApiBaseUrlFromUri utility
  - **`README.md`**: Updated documentation to reflect dynamic behavior

  ## Technical Details
  ```typescript
  // Before: Hardcoded localhost
  const DEFAULT_API_BASE_URL = "http://localhost:8000";

  // After: Dynamic hostname with SSR fallback
  const DEFAULT_API_BASE_URL = typeof window !== 'undefined'
    ? `${window.location.protocol}//${window.location.hostname}:8000`
    : "http://localhost:8000";
```

  Resolves #208