### PR TITLE
add url output mode in batch get chunks

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -579,6 +579,7 @@ async def batch_get_chunks(batch_request: Dict[str, Any], auth: AuthContext = De
         folder_name = batch_request.get("folder_name")
         end_user_id = batch_request.get("end_user_id")
         use_colpali = batch_request.get("use_colpali")
+        output_format = batch_request.get("output_format")
 
         if not sources:
             perf.log_summary("No sources provided")
@@ -595,6 +596,9 @@ async def batch_get_chunks(batch_request: Dict[str, Any], auth: AuthContext = De
 
         normalized_folder_name = normalize_folder_name(folder_name) if folder_name is not None else None
 
+        if output_format and output_format not in {"base64", "url"}:
+            raise HTTPException(status_code=400, detail="output_format must be 'base64' or 'url'")
+
         # Main batch retrieval operation
         perf.start_phase("batch_retrieve_chunks")
         results = await document_service.batch_retrieve_chunks(
@@ -603,6 +607,7 @@ async def batch_get_chunks(batch_request: Dict[str, Any], auth: AuthContext = De
             normalized_folder_name,
             end_user_id,
             use_colpali,
+            output_format or "base64",
         )
 
         # Log consolidated performance summary

--- a/core/services/document_service.py
+++ b/core/services/document_service.py
@@ -883,6 +883,7 @@ class DocumentService:
         folder_name: Optional[Union[str, List[str]]] = None,
         end_user_id: Optional[str] = None,
         use_colpali: Optional[bool] = None,
+        output_format: str = "base64",
     ) -> List[ChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number in a single batch operation.
@@ -893,6 +894,7 @@ class DocumentService:
             folder_name: Optional folder to scope the operation to
             end_user_id: Optional end-user ID to scope the operation to
             use_colpali: Whether to use colpali multimodal features for image chunks
+            output_format: How to return image chunks (base64 data or presigned URLs)
 
         Returns:
             List of ChunkResult objects
@@ -989,7 +991,12 @@ class DocumentService:
         logger.debug(f"Sorted {len(chunks)} chunks by score")
 
         # Convert to chunk results
-        results = await self._create_chunk_results(auth, chunks, preloaded_docs=authorized_doc_map)
+        results = await self._create_chunk_results(
+            auth,
+            chunks,
+            preloaded_docs=authorized_doc_map,
+            output_format=output_format,
+        )
         logger.info(f"Batch retrieved {len(results)} chunks out of {len(chunk_ids)} requested")
         return results
 

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `retrieve_chunks`: New `output_format` parameter (`"base64"` | `"url"`). When set to `"url"`, image chunks are returned as presigned URLs in `content` and `download_url` is populated. Default remains `"base64"` for backward compatibility.
 - `retrieve_chunks`: `padding` parameter surfaced consistently in SDK convenience methods (folder/user scopes) to fetch neighboring page chunks for ColPali.
+- `batch_get_chunks`: `output_format` parameter mirrors retrieval APIs so batch lookups can request presigned URLs for image chunks.
 
 ### Changed
 - Image handling in SDK parsing: When `output_format="url"`, `FinalChunkResult.content` is a string URL for image chunks; when `"base64"`, the SDK attempts to decode to `PIL.Image` (unchanged behavior).
 
 ### Notes
 - Server now hot-swaps base64/data-URI image chunks into binary storage when necessary and returns a presigned URL. In local dev, URLs may be `file://...` paths; in S3-backed deployments, HTTPS presigned URLs.
-- API accepts `output_format` on `/retrieve/chunks` and `/retrieve/chunks/grouped`.
+- API accepts `output_format` on `/retrieve/chunks`, `/retrieve/chunks/grouped`, and `/batch/chunks`.
 
 ## [1.0.0] - 2024-01-15
 

--- a/sdks/python/morphik/_internal.py
+++ b/sdks/python/morphik/_internal.py
@@ -455,6 +455,7 @@ class _MorphikClientLogic:
         folder_name: Optional[Union[str, List[str]]],
         end_user_id: Optional[str],
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Prepare request for batch_get_chunks endpoint"""
         source_dicts = []
@@ -471,6 +472,8 @@ class _MorphikClientLogic:
             request["folder_name"] = folder_name
         if end_user_id:
             request["end_user_id"] = end_user_id
+        if output_format:
+            request["output_format"] = output_format
         return request
 
     def _prepare_create_graph_request(

--- a/sdks/python/morphik/async_.py
+++ b/sdks/python/morphik/async_.py
@@ -493,6 +493,7 @@ class AsyncFolder:
         sources: List[Union[ChunkSource, Dict[str, Any]]],
         additional_folders: Optional[List[str]] = None,
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> List[FinalChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number in a single batch operation within this folder.
@@ -501,12 +502,19 @@ class AsyncFolder:
             sources: List of ChunkSource objects or dictionaries with document_id and chunk_number
             additional_folders: Optional list of additional folder names to further scope operations
             use_colpali: Whether to use ColPali-style embedding model
+            output_format: Controls how image chunks are returned (e.g., "base64" or "url")
 
         Returns:
             List[FinalChunkResult]: List of chunk results
         """
         merged = self._merge_folders(additional_folders)
-        request = self._client._logic._prepare_batch_get_chunks_request(sources, merged, None, use_colpali)
+        request = self._client._logic._prepare_batch_get_chunks_request(
+            sources,
+            merged,
+            None,
+            use_colpali,
+            output_format,
+        )
         response = await self._client._request("POST", "batch/chunks", data=request)
         return self._client._logic._parse_chunk_result_list_response(response)
 
@@ -1014,6 +1022,7 @@ class AsyncUserScope:
         sources: List[Union[ChunkSource, Dict[str, Any]]],
         folder_name: Optional[Union[str, List[str]]] = None,
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> List[FinalChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number in a single batch operation for this end user.
@@ -1022,12 +1031,17 @@ class AsyncUserScope:
             sources: List of ChunkSource objects or dictionaries with document_id and chunk_number
             folder_name: Optional folder name (or list of names) to scope the request
             use_colpali: Whether to use ColPali-style embedding model
+            output_format: Controls how image chunks are returned (e.g., "base64" or "url")
 
         Returns:
             List[FinalChunkResult]: List of chunk results
         """
         request = self._client._logic._prepare_batch_get_chunks_request(
-            sources, self._folder_name, self._end_user_id, use_colpali
+            sources,
+            self._folder_name,
+            self._end_user_id,
+            use_colpali,
+            output_format,
         )
         response = await self._client._request("POST", "batch/chunks", data=request)
         return self._client._logic._parse_chunk_result_list_response(response)
@@ -2118,6 +2132,7 @@ class AsyncMorphik(_ScopedOperationsMixin):
         sources: List[Union[ChunkSource, Dict[str, Any]]],
         folder_name: Optional[Union[str, List[str]]] = None,
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> List[FinalChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number in a single batch operation.
@@ -2126,12 +2141,19 @@ class AsyncMorphik(_ScopedOperationsMixin):
             sources: List of ChunkSource objects or dictionaries with document_id and chunk_number
             folder_name: Optional folder name (or list of names) to scope the request
             use_colpali: Whether to use ColPali-style embedding model
+            output_format: Controls how image chunks are returned (e.g., "base64" or "url")
 
         Returns:
             List[FinalChunkResult]: List of chunk results
 
         """
-        request = self._logic._prepare_batch_get_chunks_request(sources, folder_name, None, use_colpali)
+        request = self._logic._prepare_batch_get_chunks_request(
+            sources,
+            folder_name,
+            None,
+            use_colpali,
+            output_format,
+        )
         response = await self._request("POST", "batch/chunks", data=request)
         return self._logic._parse_chunk_result_list_response(response)
 

--- a/sdks/python/morphik/sync.py
+++ b/sdks/python/morphik/sync.py
@@ -495,6 +495,7 @@ class Folder:
         sources: List[Union[ChunkSource, Dict[str, Any]]],
         additional_folders: Optional[List[str]] = None,
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> List[FinalChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number in this folder.
@@ -503,12 +504,19 @@ class Folder:
             sources: List of ChunkSource objects or dictionaries with document_id and chunk_number
             additional_folders: Optional list of extra folders to include in the scope
             use_colpali: Whether to request multimodal chunks when available
+            output_format: Controls how image chunks are returned (e.g., "base64" or "url")
 
         Returns:
             List[FinalChunkResult]: List of chunk results
         """
         merged = self._merge_folders(additional_folders)
-        request = self._client._logic._prepare_batch_get_chunks_request(sources, merged, None, use_colpali)
+        request = self._client._logic._prepare_batch_get_chunks_request(
+            sources,
+            merged,
+            None,
+            use_colpali,
+            output_format,
+        )
 
         response = self._client._request("POST", "batch/chunks", data=request)
         return self._client._logic._parse_chunk_result_list_response(response)
@@ -1035,6 +1043,7 @@ class UserScope:
         sources: List[Union[ChunkSource, Dict[str, Any]]],
         additional_folders: Optional[List[str]] = None,
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> List[FinalChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number in this folder.
@@ -1043,12 +1052,19 @@ class UserScope:
             sources: List of ChunkSource objects or dictionaries with document_id and chunk_number
             additional_folders: Optional list of extra folders to include in the scope
             use_colpali: Whether to request multimodal chunks when available
+            output_format: Controls how image chunks are returned (e.g., "base64" or "url")
 
         Returns:
             List[FinalChunkResult]: List of chunk results
         """
         merged = self._merge_folders(additional_folders)
-        request = self._client._logic._prepare_batch_get_chunks_request(sources, merged, None, use_colpali)
+        request = self._client._logic._prepare_batch_get_chunks_request(
+            sources,
+            merged,
+            None,
+            use_colpali,
+            output_format,
+        )
 
         response = self._client._request("POST", "batch/chunks", data=request)
         return self._client._logic._parse_chunk_result_list_response(response)
@@ -2166,6 +2182,7 @@ class Morphik(_ScopedOperationsMixin):
         sources: List[Union[ChunkSource, Dict[str, Any]]],
         folder_name: Optional[Union[str, List[str]]] = None,
         use_colpali: bool = True,
+        output_format: Optional[str] = None,
     ) -> List[FinalChunkResult]:
         """
         Retrieve specific chunks by their document ID and chunk number.
@@ -2173,12 +2190,20 @@ class Morphik(_ScopedOperationsMixin):
         Args:
             sources: List of ChunkSource objects or dictionaries with document_id and chunk_number
             folder_name: Optional folder name (or list of names) to scope the request
+            use_colpali: Whether to request multimodal chunks when available
+            output_format: Controls how image chunks are returned (e.g., "base64" or "url")
 
         Returns:
             List[FinalChunkResult]: List of chunk results
 
         """
-        request = self._logic._prepare_batch_get_chunks_request(sources, folder_name, None, use_colpali)
+        request = self._logic._prepare_batch_get_chunks_request(
+            sources,
+            folder_name,
+            None,
+            use_colpali,
+            output_format,
+        )
         response = self._request("POST", "batch/chunks", data=request)
         return self._logic._parse_chunk_result_list_response(response)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an output_format option to batch chunk retrieval to return image chunks as base64 or presigned URLs, and wires this through the Python SDK.
> 
> - **API/Backend**:
>   - `POST /batch/chunks`: accepts `output_format` (`"base64"` | `"url"`), validates input, defaults to `"base64"`.
>   - Propagates `output_format` through `DocumentService.batch_retrieve_chunks(...)` to `_create_chunk_results(...)` for image URL generation.
> - **Python SDK**:
>   - Adds `output_format` param to all `batch_get_chunks` helpers (root, folder, user scopes; async and sync) and request builder.
>   - Updates CHANGELOG to document new `output_format` support for batch chunk retrieval and API note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70c0126cf399d9504ae6ed492b7fafce57d99b32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->