### PR TITLE
Fix SDK connection with plain URIs (no embedded credentials)

### DIFF
--- a/sdks/python/morphik/_internal.py
+++ b/sdks/python/morphik/_internal.py
@@ -64,15 +64,20 @@ class _MorphikClientLogic:
         if not parsed.netloc:
             raise ValueError("Invalid URI format")
 
-        # Split host and auth parts
-        auth, host = parsed.netloc.split("@")
-        _, self._auth_token = auth.split(":")
+        if "@" in parsed.netloc:
+            # URI contains embedded credentials: scheme://name:token@host
+            auth, host = parsed.netloc.split("@")
+            _, self._auth_token = auth.split(":")
 
-        # Set base URL
-        self._base_url = f"{'http' if self._is_local else 'https'}://{host}"
+            # Set base URL
+            self._base_url = f"{'http' if self._is_local else 'https'}://{host}"
 
-        # Basic token validation
-        jwt.decode(self._auth_token, options={"verify_signature": False})
+            # Basic token validation
+            jwt.decode(self._auth_token, options={"verify_signature": False})
+        else:
+            # Plain URI without credentials (e.g. http://0.0.0.0:8000)
+            self._auth_token = None
+            self._base_url = f"{parsed.scheme}://{parsed.netloc}"
 
     def _get_url(self, endpoint: str) -> str:
         """Get the full URL for an API endpoint"""


### PR DESCRIPTION
## Summary
- Fixes `ValueError: not enough values to unpack` when connecting with a plain URI like `http://0.0.0.0:8000`
- `_setup_auth` assumed every URI had `@`-embedded credentials (`name:token@host`), making it impossible to connect to a non-localhost server without auth
- Now checks for `@` in the netloc: if present, parses credentials as before; if absent, uses the URI directly as the base URL with no auth token

## Test plan
- [ ] `Morphik(uri="http://0.0.0.0:8000")` no longer crashes
- [ ] `Morphik(uri="http://192.168.1.100:8000")` works for LAN deployments
- [ ] `Morphik()` still defaults to `http://localhost:8000`
- [ ] Credential-embedded URIs (`name:token@host`) continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)