### PR TITLE
feat(core): improve diagnostics for ingestion and embedding

### DIFF
--- a/core/embedding/litellm_embedding.py
+++ b/core/embedding/litellm_embedding.py
@@ -91,7 +91,11 @@ class LiteLLMEmbeddingModel(BaseEmbeddingModel):
 
             return embeddings
         except Exception as e:
-            logger.error(f"Error generating embeddings with LiteLLM: {e}")
+            logger.error(
+                f"Error generating embeddings with LiteLLM: {e}. "
+                f"Context: model_key={self.model_key}, model_name={self.model_config.get('model_name')}, "
+                f"api_base={self.model_config.get('api_base', 'default')}, num_texts={len(texts)}"
+            )
             raise
 
     async def embed_query(self, text: str) -> List[float]:

--- a/core/tests/unit/test_ingestion_worker_diagnostics_helpers.py
+++ b/core/tests/unit/test_ingestion_worker_diagnostics_helpers.py
@@ -1,0 +1,269 @@
+"""
+Unit tests for ingestion worker diagnostic helper functions.
+
+These tests validate the pure helper functions extracted from ingestion_worker.py
+for testability. The helpers are deterministic with no side effects.
+"""
+
+from core.workers.ingestion_diagnostics import format_no_content_chunks_error, should_warn_empty_parsing
+
+
+class TestShouldWarnEmptyParsing:
+    """Tests for the should_warn_empty_parsing predicate."""
+
+    def test_empty_string_warns_when_text_expected(self):
+        """Empty string should trigger warning when text parsing was expected."""
+        assert (
+            should_warn_empty_parsing(
+                text="",
+                skip_text_parsing=False,
+                xml_processing=False,
+            )
+            is True
+        )
+
+    def test_whitespace_only_warns_when_text_expected(self):
+        """Whitespace only text should trigger warning when text parsing was expected."""
+        assert (
+            should_warn_empty_parsing(
+                text="   \n\t  ",
+                skip_text_parsing=False,
+                xml_processing=False,
+            )
+            is True
+        )
+
+    def test_non_empty_text_does_not_warn(self):
+        """Non-empty text should not trigger warning."""
+        assert (
+            should_warn_empty_parsing(
+                text="Some actual content",
+                skip_text_parsing=False,
+                xml_processing=False,
+            )
+            is False
+        )
+
+    def test_skip_text_parsing_suppresses_warning(self):
+        """When skip_text_parsing is True, no warning even for empty text."""
+        assert (
+            should_warn_empty_parsing(
+                text="",
+                skip_text_parsing=True,
+                xml_processing=False,
+            )
+            is False
+        )
+
+    def test_xml_processing_suppresses_warning(self):
+        """When xml_processing is True, no warning even for empty text."""
+        assert (
+            should_warn_empty_parsing(
+                text="",
+                skip_text_parsing=False,
+                xml_processing=True,
+            )
+            is False
+        )
+
+    def test_both_flags_suppress_warning(self):
+        """When both flags are True, no warning."""
+        assert (
+            should_warn_empty_parsing(
+                text="",
+                skip_text_parsing=True,
+                xml_processing=True,
+            )
+            is False
+        )
+
+    def test_text_with_only_newlines_warns(self):
+        """Text with only newlines should trigger warning."""
+        assert (
+            should_warn_empty_parsing(
+                text="\n\n\n",
+                skip_text_parsing=False,
+                xml_processing=False,
+            )
+            is True
+        )
+
+    def test_text_with_content_after_whitespace_does_not_warn(self):
+        """Text with content after whitespace should not warn."""
+        assert (
+            should_warn_empty_parsing(
+                text="   content",
+                skip_text_parsing=False,
+                xml_processing=False,
+            )
+            is False
+        )
+
+
+class TestFormatNoContentChunksError:
+    """Tests for the format_no_content_chunks_error formatter."""
+
+    def test_message_contains_required_prefix(self):
+        """Message should start with the expected error description."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert msg.startswith("No content chunks (text or image) could be extracted from the document.")
+
+    def test_message_contains_document_id(self):
+        """Message should contain the document_id."""
+        msg = format_no_content_chunks_error(
+            document_id="my-unique-doc-id",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert "document_id=my-unique-doc-id" in msg
+
+    def test_message_contains_mime_type(self):
+        """Message should contain the mime_type."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="image/png",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert "mime_type=image/png" in msg
+
+    def test_message_contains_none_mime_type(self):
+        """Message should show None when mime_type is None."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type=None,
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert "mime_type=None" in msg
+
+    def test_message_contains_using_colpali_true(self):
+        """Message should contain using_colpali=True when set."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=True,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert "using_colpali=True" in msg
+
+    def test_message_contains_using_colpali_false(self):
+        """Message should contain using_colpali=False when not set."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert "using_colpali=False" in msg
+
+    def test_message_contains_skip_text_parsing(self):
+        """Message should contain skip_text_parsing value."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=True,
+            xml_processing=False,
+            text="",
+        )
+        assert "skip_text_parsing=True" in msg
+
+    def test_message_contains_xml_processing(self):
+        """Message should contain xml_processing value."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=True,
+            text="",
+        )
+        assert "xml_processing=True" in msg
+
+    def test_text_none_gives_text_length_zero(self):
+        """When text is None, text_length should be 0."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text=None,
+        )
+        assert "text_length=0" in msg
+
+    def test_text_empty_string_gives_text_length_zero(self):
+        """When text is empty string, text_length should be 0."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="",
+        )
+        assert "text_length=0" in msg
+
+    def test_text_with_content_gives_correct_length(self):
+        """When text has content, text_length should be len(text)."""
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text="abc",
+        )
+        assert "text_length=3" in msg
+
+    def test_text_with_longer_content(self):
+        """Text length should reflect actual content length."""
+        long_text = "x" * 12345
+        msg = format_no_content_chunks_error(
+            document_id="doc-123",
+            mime_type="application/pdf",
+            using_colpali=False,
+            skip_text_parsing=False,
+            xml_processing=False,
+            text=long_text,
+        )
+        assert "text_length=12345" in msg
+
+    def test_all_fields_present_in_context(self):
+        """All required fields should be present in a single message."""
+        msg = format_no_content_chunks_error(
+            document_id="test-doc",
+            mime_type="text/plain",
+            using_colpali=True,
+            skip_text_parsing=True,
+            xml_processing=True,
+            text="hello",
+        )
+        # Verify all fields are present
+        assert "document_id=test-doc" in msg
+        assert "mime_type=text/plain" in msg
+        assert "using_colpali=True" in msg
+        assert "skip_text_parsing=True" in msg
+        assert "xml_processing=True" in msg
+        assert "text_length=5" in msg
+        # Verify it contains the Context prefix
+        assert "Context:" in msg

--- a/core/tests/unit/test_litellm_embedding_error_logging.py
+++ b/core/tests/unit/test_litellm_embedding_error_logging.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for LiteLLM embedding error logging diagnostics.
+
+Tests verify that when litellm.aembedding raises an exception:
+- The error log includes diagnostic context, such as model_key, model_name, api_base, num_texts
+- The original exception type is re-raised unchanged
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Marker for error log identification matching exception text in litellm_embedding.py
+ERROR_LOG_MARKER = "Error generating embeddings with LiteLLM:"
+
+
+def find_error_log_record(caplog_records, marker=ERROR_LOG_MARKER):
+    """
+    Find the ERROR log record containing the marker substring.
+
+    Filters by:
+    - Log level == ERROR
+    - Message contains the marker substring
+
+    Returns the first matching record, or None if not found.
+    """
+    for record in caplog_records:
+        if record.levelno == logging.ERROR and marker in record.message:
+            return record
+    return None
+
+
+class TestLiteLLMEmbeddingErrorLogging:
+    """Test improved error logging in LiteLLMEmbeddingModel.embed_documents."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Create a mock settings object with required attributes."""
+        settings = MagicMock()
+        settings.REGISTERED_MODELS = {
+            "test_embedding": {
+                "model_name": "ollama/nomic-embed-text",
+                "api_base": "http://localhost:11434",
+            }
+        }
+        settings.VECTOR_DIMENSIONS = 768
+        settings.LITELLM_DUMMY_API_KEY = "test-dummy-key"
+        return settings
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_logs_context_on_connection_error(self, mock_settings, caplog):
+        """
+        Test that when litellm.aembedding raises ConnectionError,
+        the error log includes model_key, model_name, api_base, and num_texts.
+        """
+        with patch("core.embedding.litellm_embedding.get_settings", return_value=mock_settings):
+            from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
+
+            model = LiteLLMEmbeddingModel("test_embedding")
+
+            error_message = "Connection refused to http://localhost:11434"
+            connection_error = ConnectionError(error_message)
+
+            with patch(
+                "core.embedding.litellm_embedding.litellm.aembedding", new_callable=AsyncMock
+            ) as mock_aembedding:
+                mock_aembedding.side_effect = connection_error
+
+                with caplog.at_level(logging.ERROR, logger="core.embedding.litellm_embedding"):
+                    with pytest.raises(ConnectionError) as exc_info:
+                        await model.embed_documents(["test text 1", "test text 2"])
+
+                    # Verify exception type preserved and message matches
+                    assert error_message in str(exc_info.value)
+
+                    # Find the ERROR log record with our diagnostic marker
+                    error_record = find_error_log_record(caplog.records)
+                    assert error_record is not None, (
+                        f"Expected an ERROR log containing '{ERROR_LOG_MARKER}' but found none. "
+                        f"Records: {[r.message for r in caplog.records]}"
+                    )
+
+                    log_message = error_record.message
+
+                    # Check all required context fields are present
+                    assert "model_key=test_embedding" in log_message
+                    assert "model_name=ollama/nomic-embed-text" in log_message
+                    assert "api_base=http://localhost:11434" in log_message
+                    assert "num_texts=2" in log_message
+                    assert "Connection refused" in log_message
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_logs_default_api_base_when_not_configured(self, caplog):
+        """
+        Test that when api_base is not in model config, log shows 'default'.
+        """
+        settings = MagicMock()
+        settings.REGISTERED_MODELS = {
+            "openai_embedding": {
+                "model_name": "text-embedding-3-small",
+                # No api_base - uses OpenAI default
+            }
+        }
+        settings.VECTOR_DIMENSIONS = 1536
+        settings.LITELLM_DUMMY_API_KEY = "test-dummy-key"
+
+        with patch("core.embedding.litellm_embedding.get_settings", return_value=settings):
+            from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
+
+            model = LiteLLMEmbeddingModel("openai_embedding")
+
+            error_message = "Invalid API key"
+            api_error = Exception(error_message)
+
+            with patch(
+                "core.embedding.litellm_embedding.litellm.aembedding", new_callable=AsyncMock
+            ) as mock_aembedding:
+                mock_aembedding.side_effect = api_error
+
+                with caplog.at_level(logging.ERROR, logger="core.embedding.litellm_embedding"):
+                    with pytest.raises(Exception) as exc_info:
+                        await model.embed_documents(["single text"])
+
+                    # Verify exception message matches
+                    assert error_message in str(exc_info.value)
+
+                    # Find the ERROR log record with our diagnostic marker
+                    error_record = find_error_log_record(caplog.records)
+                    assert error_record is not None, (
+                        f"Expected an ERROR log containing '{ERROR_LOG_MARKER}' but found none. "
+                        f"Records: {[r.message for r in caplog.records]}"
+                    )
+
+                    log_message = error_record.message
+                    assert "api_base=default" in log_message
+                    assert "num_texts=1" in log_message
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_preserves_exception_type(self, mock_settings):
+        """
+        Test that various exception types are re-raised unchanged.
+        """
+        with patch("core.embedding.litellm_embedding.get_settings", return_value=mock_settings):
+            from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
+
+            model = LiteLLMEmbeddingModel("test_embedding")
+
+            # Test with different exception types and their messages
+            test_cases = [
+                (ValueError, "Bad value"),
+                (TimeoutError, "Request timed out"),
+                (RuntimeError, "Runtime failure"),
+            ]
+
+            for exception_type, message in test_cases:
+                original_exception = exception_type(message)
+
+                with patch(
+                    "core.embedding.litellm_embedding.litellm.aembedding", new_callable=AsyncMock
+                ) as mock_aembedding:
+                    mock_aembedding.side_effect = original_exception
+
+                    with pytest.raises(exception_type) as exc_info:
+                        await model.embed_documents(["test"])
+
+                    # Verify exception type preserved and message matches
+                    assert message in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_embed_documents_empty_texts_returns_empty_list(self, mock_settings):
+        """
+        Test that empty input returns empty list without calling litellm.
+        """
+        with patch("core.embedding.litellm_embedding.get_settings", return_value=mock_settings):
+            from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
+
+            model = LiteLLMEmbeddingModel("test_embedding")
+
+            with patch(
+                "core.embedding.litellm_embedding.litellm.aembedding", new_callable=AsyncMock
+            ) as mock_aembedding:
+                result = await model.embed_documents([])
+
+                assert result == []
+                mock_aembedding.assert_not_called()

--- a/core/workers/ingestion_diagnostics.py
+++ b/core/workers/ingestion_diagnostics.py
@@ -1,0 +1,47 @@
+"""
+Pure diagnostic helper functions for ingestion worker.
+
+To facilitate testability, these are deterministic functions with no side effects.
+"""
+
+from typing import Optional
+
+
+def should_warn_empty_parsing(text: str, skip_text_parsing: bool, xml_processing: bool) -> bool:
+    """
+    Return True if we should emit a warning about empty parsing results.
+
+    This happens when:
+    - We did not skip text parsing
+    - We are not processing XML, which has its own chunk flow
+    - The extracted text is empty or only contains whitespace
+    """
+    return not skip_text_parsing and not xml_processing and not text.strip()
+
+
+def format_no_content_chunks_error(
+    document_id: str,
+    mime_type: Optional[str],
+    using_colpali: bool,
+    skip_text_parsing: bool,
+    xml_processing: bool,
+    text: Optional[str],
+) -> str:
+    """
+    Format the error message for when no content chunks could be extracted.
+
+    Returns the complete error message string with all diagnostic context.
+    """
+    text_length = len(text) if text else 0
+    return (
+        f"No content chunks (text or image) could be extracted from the document. "
+        f"Context: document_id={document_id}, mime_type={mime_type}, "
+        f"using_colpali={using_colpali}, skip_text_parsing={skip_text_parsing}, "
+        f"xml_processing={xml_processing}, text_length={text_length}"
+    )
+
+
+__all__ = (
+    "should_warn_empty_parsing",
+    "format_no_content_chunks_error",
+)


### PR DESCRIPTION
Ref: #340

### Changes
- Ingestion: warn when parsing yields empty text in cases where text is expected
- Ingestion: include diagnostic context for the error raised when there are no no content chunks
- Embedding: enrich LiteLLM embedding error logs with model_key, model_name, api_base, num_texts context

### Tests
- Added unit tests for ingestion diagnostics helpers
- Added unit tests for LiteLLM embedding error logging

### Notes
- Follow-up PR planned for completion side LiteLLM diagnostics to keep this PR focused.
