### PR TITLE
fix(chat-ui): load selector data in non-localhost deployments

### DIFF
--- a/ee/ui-component/components/chat/ChatSection.tsx
+++ b/ee/ui-component/components/chat/ChatSection.tsx
@@ -314,7 +314,7 @@ const ChatSection: React.FC<ChatSectionProps> = ({
   useEffect(() => {
     // Define a function to handle data fetching
     const fetchData = async () => {
-      if (authToken || apiBaseUrl.includes("localhost")) {
+      if (apiBaseUrl) {
         console.log("ChatSection: Fetching data with auth token:", !!authToken);
         await fetchFolders();
         await fetchDocuments();


### PR DESCRIPTION
## Summary
- remove the localhost-specific gate in `ChatSection` initial data preload
- fetch chat document/folder selector data whenever `apiBaseUrl` is present
- preserve existing auth header behavior (Bearer when token exists; no Authorization header in bypass mode)

## Root Cause
`ChatSection` only fetched selector data when:
- a token was present, or
- `apiBaseUrl` contained `localhost`

In self-hosted LAN/IP deployments with `bypass_auth_mode=true`, neither condition is true, so `/folders/details` and `/documents/list_docs` were never called.

Closes #379
Issue: https://github.com/morphik-org/morphik-core/issues/379
