### PR TITLE
fix(pdf-viewer): support paginated /documents response

### DIFF
--- a/ee/ui-component/components/pdf/PDFViewer.tsx
+++ b/ee/ui-component/components/pdf/PDFViewer.tsx
@@ -679,7 +679,12 @@ export function PDFViewer({ apiBaseUrl, authToken, initialDocumentId, onChatTogg
       });
 
       if (response.ok) {
-        const allDocuments = await response.json();
+        const rawData = await response.json();
+        const allDocuments = Array.isArray(rawData)
+          ? rawData
+          : Array.isArray(rawData?.documents)
+            ? rawData.documents
+            : [];
         console.log("All documents received:", allDocuments.length);
 
         // Filter for PDF documents only


### PR DESCRIPTION
## Summary
- normalize PDFViewer document list response parsing to handle both formats:
  - legacy array response
  - current paginated object (`{ documents: [...] }`)
- prevent runtime `filter is not a function` when `/documents` returns `ListDocsResponse`

## Root Cause
`PDFViewer` assumed `POST /documents` returned an array and called `.filter(...)` directly.
The backend now returns a wrapped object with a `documents` field.

Closes #378
Issue: https://github.com/morphik-org/morphik-core/issues/378
