### PR TITLE
fix: handle paginated documents response and non-localhost auth guard (issue 378 and 379)

### DIFF
--- a/ee/ui-component/components/chat/ChatSection.tsx
+++ b/ee/ui-component/components/chat/ChatSection.tsx
@@ -314,7 +314,7 @@ const ChatSection: React.FC<ChatSectionProps> = ({
   useEffect(() => {
     // Define a function to handle data fetching
     const fetchData = async () => {
-      if (authToken || apiBaseUrl.includes("localhost")) {
+      if (authToken || apiBaseUrl) {
         console.log("ChatSection: Fetching data with auth token:", !!authToken);
         await fetchFolders();
         await fetchDocuments();

--- a/ee/ui-component/components/pdf/PDFViewer.tsx
+++ b/ee/ui-component/components/pdf/PDFViewer.tsx
@@ -679,7 +679,8 @@ export function PDFViewer({ apiBaseUrl, authToken, initialDocumentId, onChatTogg
       });
 
       if (response.ok) {
-        const allDocuments = await response.json();
+        const _rawData = await response.json();
+        const allDocuments = Array.isArray(_rawData) ? _rawData : _rawData.documents || [];
         console.log("All documents received:", allDocuments.length);
 
         // Filter for PDF documents only


### PR DESCRIPTION
Fixes #378
Fixes #379

## Changes

**PDFViewer.tsx** — handle paginated /documents response
The PDF Viewer assumed POST /documents returns a plain array. 
The backend now returns `{ documents: [...] }`. This fix handles both formats.

**ChatSection.tsx** — fix document selector in non-localhost deployments  
The fetch guard `apiBaseUrl.includes("localhost")` silently blocked 
document loading for all non-localhost deployments with bypass_auth_mode.
Changed to `apiBaseUrl` which is sufficient since the function already 
guards against falsy apiBaseUrl internally.