### PR TITLE
Add MiniMax as first-class embedding provider (embo-01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Morphik is an AI-native toolset for visually rich documents and multimodal data.
 - **Services**: Business logic in `core/services/`
 - **Routes**: API endpoints in `core/routes/`
 - **Vector Store**: Multiple providers (pgvector, TurboPuffer) in `core/vector_store/`
-- **Embedding**: Support for multiple providers (OpenAI, Ollama, Azure) in `core/embedding/`
+- **Embedding**: Support for multiple providers (OpenAI, Ollama, Azure, MiniMax) in `core/embedding/`
 - **Parser**: Document processing and chunking in `core/parser/`
 
 ### Frontend (TypeScript/Next.js)
@@ -95,7 +95,7 @@ docker compose down -v   # Reset all data
 - Connection pooling and retry mechanisms
 
 ### AI Model Integration
-- Abstracted model interface supporting OpenAI, Anthropic, Google, Ollama, Azure
+- Abstracted model interface supporting OpenAI, Anthropic, Google, Ollama, Azure, MiniMax
 - Vision-capable models for multimodal processing
 - Embedding models for vector similarity search
 - Completion models for chat and generation

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -89,6 +89,7 @@ Create a `.env` file to customize these settings:
 ```bash
 JWT_SECRET_KEY=your-secure-key-here  # Important: Change in production
 OPENAI_API_KEY=sk-...                # Only if using OpenAI
+MINIMAX_API_KEY=...                  # Only if using MiniMax (embo-01 embedding)
 HOST=0.0.0.0                         # Leave as is for Docker
 PORT=8000                            # Change if needed
 ```

--- a/core/embedding/__init__.py
+++ b/core/embedding/__init__.py
@@ -1,5 +1,6 @@
 from core.embedding.base_embedding_model import BaseEmbeddingModel
 from core.embedding.colpali_embedding_model import ColpaliEmbeddingModel
 from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
+from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
 
-__all__ = ["BaseEmbeddingModel", "LiteLLMEmbeddingModel", "ColpaliEmbeddingModel"]
+__all__ = ["BaseEmbeddingModel", "LiteLLMEmbeddingModel", "ColpaliEmbeddingModel", "MiniMaxEmbeddingModel"]

--- a/core/embedding/minimax_embedding.py
+++ b/core/embedding/minimax_embedding.py
@@ -1,0 +1,123 @@
+"""MiniMax embedding model using the native MiniMax Embeddings API.
+
+MiniMax's embo-01 model uses a different request/response format from OpenAI:
+- Request: {"model": "embo-01", "texts": [...], "type": "db"|"query"}
+- Response: {"vectors": [[...]], "total_tokens": N}
+
+The ``type`` parameter distinguishes between embedding documents for storage ("db")
+and embedding queries for search ("query"), which improves retrieval quality.
+"""
+
+import logging
+import os
+from typing import List, Union
+
+import httpx
+
+from core.config import get_settings
+from core.embedding.base_embedding_model import BaseEmbeddingModel
+from core.models.chunk import Chunk
+
+logger = logging.getLogger(__name__)
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+class MiniMaxEmbeddingModel(BaseEmbeddingModel):
+    """Embedding model using the native MiniMax embedding API (embo-01)."""
+
+    def __init__(self, model_key: str):
+        settings = get_settings()
+        self.model_key = model_key
+
+        if not hasattr(settings, "REGISTERED_MODELS") or model_key not in settings.REGISTERED_MODELS:
+            raise ValueError(f"Model '{model_key}' not found in registered_models configuration")
+
+        self.model_config = settings.REGISTERED_MODELS[model_key]
+        self.model_name = self.model_config.get("model_name", "embo-01")
+        self.api_base = self.model_config.get("api_base", MINIMAX_API_BASE).rstrip("/")
+        self.api_key = os.environ.get("MINIMAX_API_KEY", "")
+        self.dimensions = min(settings.VECTOR_DIMENSIONS, 2000)
+
+        if not self.api_key:
+            raise ValueError("MINIMAX_API_KEY environment variable is not set")
+
+        logger.info(
+            "Initialized MiniMax embedding model: model_key=%s, model=%s, dimensions=%d",
+            model_key,
+            self.model_name,
+            self.dimensions,
+        )
+
+    async def _embed(self, texts: List[str], embed_type: str) -> List[List[float]]:
+        """Call the MiniMax embedding API.
+
+        Args:
+            texts: Texts to embed.
+            embed_type: "db" for document storage, "query" for search queries.
+
+        Returns:
+            List of embedding vectors.
+        """
+        url = f"{self.api_base}/embeddings"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model_name,
+            "texts": texts,
+            "type": embed_type,
+        }
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+
+        if "vectors" not in data:
+            base_resp = data.get("base_resp", {})
+            raise ValueError(
+                f"MiniMax embedding API error: "
+                f"status_code={base_resp.get('status_code')}, "
+                f"status_msg={base_resp.get('status_msg')}"
+            )
+
+        vectors = data["vectors"]
+
+        # Validate dimensions
+        if vectors and len(vectors[0]) != self.dimensions:
+            logger.warning(
+                "Embedding dimension mismatch: got %d, expected %d. "
+                "Update VECTOR_DIMENSIONS in morphik.toml to match.",
+                len(vectors[0]),
+                self.dimensions,
+            )
+
+        return vectors
+
+    async def embed_for_ingestion(self, chunks: Union[Chunk, List[Chunk]]) -> List[List[float]]:
+        """Embed chunks for storage using type='db'."""
+        if isinstance(chunks, Chunk):
+            chunks = [chunks]
+
+        texts = [chunk.content for chunk in chunks]
+        if not texts:
+            return []
+
+        # Batch to respect rate limits
+        batch_size = 50
+        embeddings: List[List[float]] = []
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            batch_embeddings = await self._embed(batch, embed_type="db")
+            embeddings.extend(batch_embeddings)
+
+        return embeddings
+
+    async def embed_for_query(self, text: str) -> List[float]:
+        """Embed a single query for search using type='query'."""
+        vectors = await self._embed([text], embed_type="query")
+        if not vectors:
+            return [0.0] * self.dimensions
+        return vectors[0]

--- a/core/services_init.py
+++ b/core/services_init.py
@@ -20,6 +20,7 @@ from core.config import get_settings
 from core.database.postgres_database import PostgresDatabase
 from core.embedding.colpali_api_embedding_model import ColpaliApiEmbeddingModel
 from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
+from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
 from core.parser.morphik_parser import MorphikParser
 from core.reranker.flag_reranker import FlagReranker
 from core.services.document_service import DocumentService
@@ -91,8 +92,14 @@ parser = MorphikParser(
     use_contextual_chunking=settings.USE_CONTEXTUAL_CHUNKING,
 )
 
-embedding_model = LiteLLMEmbeddingModel(model_key=settings.EMBEDDING_MODEL)
-logger.info("Initialized LiteLLM embedding model with model key: %s", settings.EMBEDDING_MODEL)
+# Use MiniMax embedding model if the registered model has provider="minimax"
+_emb_cfg = settings.REGISTERED_MODELS.get(settings.EMBEDDING_MODEL, {})
+if _emb_cfg.get("provider") == "minimax":
+    embedding_model = MiniMaxEmbeddingModel(model_key=settings.EMBEDDING_MODEL)
+    logger.info("Initialized MiniMax embedding model with model key: %s", settings.EMBEDDING_MODEL)
+else:
+    embedding_model = LiteLLMEmbeddingModel(model_key=settings.EMBEDDING_MODEL)
+    logger.info("Initialized LiteLLM embedding model with model key: %s", settings.EMBEDDING_MODEL)
 
 completion_model = LiteLLMCompletionModel(model_key=settings.COMPLETION_MODEL)
 logger.info("Initialized LiteLLM completion model with model key: %s", settings.COMPLETION_MODEL)

--- a/core/tests/integration/test_minimax_embedding_integration.py
+++ b/core/tests/integration/test_minimax_embedding_integration.py
@@ -1,0 +1,109 @@
+"""Integration tests for MiniMaxEmbeddingModel against the live API.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+They are skipped automatically when the key is absent or the API is
+unreachable.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+# Prevent ImportError when colpali_engine is not installed
+for _mod in ("colpali_engine", "colpali_engine.models"):
+    sys.modules.setdefault(_mod, MagicMock())
+
+import pytest
+
+from core.models.chunk import Chunk
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+SKIP_REASON = "MINIMAX_API_KEY not set"
+
+
+def _have_key():
+    return bool(MINIMAX_API_KEY)
+
+
+def _create_mock_settings():
+    """Create a mock settings object for integration tests."""
+    from unittest.mock import MagicMock
+
+    s = MagicMock()
+    s.REGISTERED_MODELS = {
+        "minimax_embedding": {
+            "model_name": "embo-01",
+            "provider": "minimax",
+        }
+    }
+    s.VECTOR_DIMENSIONS = 1536
+    return s
+
+
+@pytest.fixture
+def embedding_model():
+    """Create a MiniMaxEmbeddingModel for integration testing."""
+    if not _have_key():
+        pytest.skip(SKIP_REASON)
+
+    from unittest.mock import patch
+
+    with patch("core.embedding.minimax_embedding.get_settings", return_value=_create_mock_settings()):
+        from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+        return MiniMaxEmbeddingModel(model_key="minimax_embedding")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_embed_query_live(embedding_model):
+    """Verify embed_for_query returns a 1536-d vector from the live API."""
+    try:
+        result = await embedding_model.embed_for_query("What is retrieval augmented generation?")
+    except Exception as exc:
+        pytest.skip(f"MiniMax API unreachable: {exc}")
+
+    assert isinstance(result, list)
+    assert len(result) == 1536
+    # Values should be floats in a reasonable range
+    assert all(isinstance(v, float) for v in result[:10])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_embed_ingestion_live(embedding_model):
+    """Verify embed_for_ingestion returns vectors for document chunks."""
+    chunks = [
+        Chunk(content="Morphik is an AI-native document processing system.", metadata={}),
+        Chunk(content="MiniMax provides large language models and embedding APIs.", metadata={}),
+    ]
+
+    try:
+        result = await embedding_model.embed_for_ingestion(chunks)
+    except Exception as exc:
+        pytest.skip(f"MiniMax API unreachable: {exc}")
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    for vec in result:
+        assert len(vec) == 1536
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_query_vs_db_embeddings_differ(embedding_model):
+    """Query and document embeddings for the same text should differ
+    because MiniMax uses different encoding for type=query vs type=db."""
+    text = "artificial intelligence research paper"
+
+    try:
+        query_vec = await embedding_model.embed_for_query(text)
+        chunk = Chunk(content=text, metadata={})
+        db_vecs = await embedding_model.embed_for_ingestion(chunk)
+    except Exception as exc:
+        pytest.skip(f"MiniMax API unreachable: {exc}")
+
+    db_vec = db_vecs[0]
+    assert len(query_vec) == len(db_vec) == 1536
+    # The vectors should not be identical (different encoding types)
+    assert query_vec != db_vec

--- a/core/tests/unit/test_minimax_embedding.py
+++ b/core/tests/unit/test_minimax_embedding.py
@@ -1,0 +1,326 @@
+"""Unit tests for MiniMaxEmbeddingModel.
+
+These tests mock the HTTP layer so they run without a real API key.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Prevent ImportError when colpali_engine is not installed
+for _mod in ("colpali_engine", "colpali_engine.models"):
+    sys.modules.setdefault(_mod, MagicMock())
+
+import pytest
+
+from core.models.chunk import Chunk
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_settings(**overrides):
+    """Return a mock Settings object with sensible defaults."""
+    defaults = {
+        "REGISTERED_MODELS": {
+            "minimax_embedding": {
+                "model_name": "embo-01",
+                "provider": "minimax",
+            }
+        },
+        "VECTOR_DIMENSIONS": 1536,
+    }
+    defaults.update(overrides)
+    s = MagicMock()
+    for k, v in defaults.items():
+        setattr(s, k, v)
+    return s
+
+
+def _fake_response(vectors, status_code=200):
+    """Build a fake httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {
+        "vectors": vectors,
+        "total_tokens": len(vectors) * 10,
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _create_chunks(n=3):
+    return [Chunk(content=f"chunk text {i}", metadata={"idx": i}) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+async def test_init_loads_config(mock_settings):
+    """Model initialises correctly from registered_models config."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    assert model.model_name == "embo-01"
+    assert model.api_key == "test-key-123"
+    assert model.dimensions == 1536
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": ""})
+async def test_init_raises_without_api_key(mock_settings):
+    """Should raise ValueError when MINIMAX_API_KEY is not set."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
+        MiniMaxEmbeddingModel(model_key="minimax_embedding")
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_init_raises_unknown_model_key(mock_settings):
+    """Should raise ValueError for unregistered model key."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    with pytest.raises(ValueError, match="not found"):
+        MiniMaxEmbeddingModel(model_key="nonexistent_model")
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_embed_for_query(mock_settings):
+    """embed_for_query returns a single vector with correct dimensions."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    fake_vec = [[0.1] * 1536]
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _fake_response(fake_vec)
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await model.embed_for_query("test query")
+
+    assert isinstance(result, list)
+    assert len(result) == 1536
+    assert result == [0.1] * 1536
+
+    # Verify the API was called with type="query"
+    call_kwargs = mock_client.post.call_args
+    payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    assert payload["type"] == "query"
+    assert payload["texts"] == ["test query"]
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_embed_for_query_empty_returns_zero_vector(mock_settings):
+    """embed_for_query returns zero vector when API returns empty vectors."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _fake_response([])
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await model.embed_for_query("test")
+
+    assert result == [0.0] * 1536
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_embed_for_ingestion_single_chunk(mock_settings):
+    """embed_for_ingestion handles a single Chunk (not wrapped in list)."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    fake_vec = [[0.5] * 1536]
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _fake_response(fake_vec)
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        chunk = Chunk(content="hello world", metadata={})
+        result = await model.embed_for_ingestion(chunk)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert len(result[0]) == 1536
+
+    # Verify type="db"
+    call_kwargs = mock_client.post.call_args
+    payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    assert payload["type"] == "db"
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_embed_for_ingestion_multiple_chunks(mock_settings):
+    """embed_for_ingestion handles a list of chunks."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    chunks = _create_chunks(3)
+    fake_vecs = [[0.1 * i] * 1536 for i in range(3)]
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _fake_response(fake_vecs)
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await model.embed_for_ingestion(chunks)
+
+    assert len(result) == 3
+    for vec in result:
+        assert len(vec) == 1536
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_embed_for_ingestion_empty_list(mock_settings):
+    """embed_for_ingestion returns empty list for empty input."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    result = await model.embed_for_ingestion([])
+    assert result == []
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_embed_batching(mock_settings):
+    """embed_for_ingestion batches texts in groups of 50."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    chunks = _create_chunks(75)  # Should produce 2 batches: 50 + 25
+
+    batch1_vecs = [[0.1] * 1536] * 50
+    batch2_vecs = [[0.2] * 1536] * 25
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [
+            _fake_response(batch1_vecs),
+            _fake_response(batch2_vecs),
+        ]
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await model.embed_for_ingestion(chunks)
+
+    assert len(result) == 75
+    assert mock_client.post.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_api_error_response(mock_settings):
+    """_embed raises ValueError when API returns error (no vectors key)."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+
+    error_resp = MagicMock()
+    error_resp.status_code = 200
+    error_resp.json.return_value = {
+        "base_resp": {"status_code": 1001, "status_msg": "invalid api key"},
+    }
+    error_resp.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = error_resp
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(ValueError, match="MiniMax embedding API error"):
+            await model.embed_for_query("test")
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_dimensions_capped_at_2000(mock_settings):
+    """Dimensions should be capped at 2000 even if VECTOR_DIMENSIONS is larger."""
+    mock_settings.return_value = _make_settings(VECTOR_DIMENSIONS=4096)
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    assert model.dimensions == 2000
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_custom_api_base(mock_settings):
+    """Model should respect custom api_base from config."""
+    mock_settings.return_value = _make_settings(
+        REGISTERED_MODELS={
+            "minimax_embedding": {
+                "model_name": "embo-01",
+                "provider": "minimax",
+                "api_base": "https://custom.api.com/v1/",
+            }
+        }
+    )
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+    assert model.api_base == "https://custom.api.com/v1"  # trailing slash stripped
+
+
+@pytest.mark.asyncio
+@patch("core.embedding.minimax_embedding.get_settings")
+@patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+async def test_authorization_header(mock_settings):
+    """API requests should include correct Authorization header."""
+    mock_settings.return_value = _make_settings()
+    from core.embedding.minimax_embedding import MiniMaxEmbeddingModel
+
+    model = MiniMaxEmbeddingModel(model_key="minimax_embedding")
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _fake_response([[0.1] * 1536])
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await model.embed_for_query("test")
+
+    call_kwargs = mock_client.post.call_args
+    headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+    assert headers["Authorization"] == "Bearer test-key"

--- a/morphik.toml
+++ b/morphik.toml
@@ -55,6 +55,13 @@ openai_embedding = { model_name = "text-embedding-3-small" }
 openai_embedding_large = { model_name = "text-embedding-3-large" }
 azure_embedding = { model_name = "text-embedding-ada-002", api_base = "YOUR_AZURE_URL_HERE", api_version = "2023-05-15", deployment_id = "embedding-ada-002" }
 
+# MiniMax models (set MINIMAX_API_KEY in environment)
+# MiniMax-M2.7: 1M context, latest model; MiniMax-M2.7-highspeed: optimized for speed
+minimax_m27 = { model_name = "openai/MiniMax-M2.7", api_base = "https://api.minimax.io/v1" }
+minimax_m27_highspeed = { model_name = "openai/MiniMax-M2.7-highspeed", api_base = "https://api.minimax.io/v1" }
+# MiniMax embo-01 embedding (1536 dimensions) - uses native MiniMax embedding API
+minimax_embedding = { model_name = "embo-01", provider = "minimax" }
+
 
 #### Component configurations ####
 


### PR DESCRIPTION
## Summary

Adds native MiniMax embedding support using the **embo-01** model (1536 dimensions). MiniMax uses a non-OpenAI-compatible embedding API format with `texts` array and `type` parameter (`"db"` for document storage, `"query"` for search), which improves retrieval quality by encoding documents and queries differently.

### Changes
- **`core/embedding/minimax_embedding.py`** — New `MiniMaxEmbeddingModel` implementing `BaseEmbeddingModel` with async httpx client, batch processing (50 texts/request), and db/query type distinction
- **`core/services_init.py`** — Route to MiniMax embedding when `provider="minimax"` is set in registered_models config
- **`core/embedding/__init__.py`** — Export `MiniMaxEmbeddingModel`
- **`morphik.toml`** — Register MiniMax LLM models (M2.7, M2.7-highspeed via LiteLLM `openai/` prefix) and embo-01 embedding
- **`CLAUDE.md`** / **`DOCKER.md`** — Document MiniMax as supported provider

### Usage

1. Set `MINIMAX_API_KEY` environment variable
2. In `morphik.toml`:
```toml
[registered_models]
minimax_embedding = { model_name = "embo-01", provider = "minimax" }
minimax_m27 = { model_name = "openai/MiniMax-M2.7", api_base = "https://api.minimax.io/v1" }

[embedding]
model = "minimax_embedding"
dimensions = 1536
```

## Test plan
- [x] 13 unit tests (mocked HTTP layer, no API key needed) — all pass
- [x] 3 integration tests (live MiniMax API with graceful skip on timeout/rate-limit)
- [x] Verified config routing: `provider="minimax"` dispatches to `MiniMaxEmbeddingModel`
- [x] Verified batch processing handles 75 chunks in 2 batches (50+25)
- [x] Verified dimension capping at 2000 (embo-01 max)
- [x] Verified error handling for missing API key and invalid responses