### PR TITLE
fix(security): pin litellm to 1.82.6 to avoid TeamPCP supply chain compromise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "importlib>=1.0.4",
     "instructor>=1.8.1",
     "itsdangerous>=2.2.0",
-    "litellm>=1.69.1",
+    "litellm==1.82.6",
     "lxml>=5.2.2",
     "morphik==1.0.3",
     "ollama>=0.4.8",


### PR DESCRIPTION
## Summary

Closes #393

Pins `litellm` from `>=1.69.1` to `==1.82.6` (last known-safe version) to protect against the TeamPCP supply chain attack discovered on 2026-03-24.

## What happened

`litellm` versions **1.82.7** and **1.82.8** on PyPI were backdoored with a `litellm_init.pth` file that executes automatically on every Python process startup — **no `import litellm` needed**. The payload:

- Credential harvester (SSH keys, cloud creds, `.env` files, K8s secrets, crypto wallets)
- Kubernetes lateral movement (deploys privileged pods to every node)
- Persistent systemd backdoor (`sysmon.service`)

Since `pyproject.toml` declared `litellm>=1.69.1`, any fresh install could have resolved to the compromised versions.

## Change

```toml
# Before
"litellm>=1.69.1",

# After
"litellm==1.82.6",
```

## References

- [LiteLLM official security update](https://docs.litellm.ai/blog/security-update-march-2026)
- [Simon Willison's breakdown](https://simonwillison.net/2026/Mar/24/malicious-litellm/)
- [TeamPCP campaign — The Hacker News](https://thehackernews.com/2026/03/teampcp-backdoors-litellm-versions.html)

## Next steps

Once `litellm` publishes a verified clean release (post-1.82.8), this pin can be relaxed back to a range constraint.