### PR TITLE
Fix: re-probe unhealthy ColPali endpoints after cooldown

### DIFF
--- a/core/embedding/colpali_api_embedding_model.py
+++ b/core/embedding/colpali_api_embedding_model.py
@@ -51,9 +51,26 @@ class ColpaliApiEmbeddingModel(BaseEmbeddingModel):
 
         # Track endpoint health for failover
         self.healthy_endpoints: set[str] = set(self.endpoints)
+        self._endpoint_unhealthy_since: Dict[str, float] = {}
+        self._unhealthy_recovery_seconds: float = 60.0
         self._endpoint_latencies: dict[str, float] = {}
         self.endpoint = self.endpoints[0]
         self._latest_ingest_metrics: Dict[str, float] = {}
+
+    def _recover_endpoints(self) -> None:
+        """Re-include endpoints whose unhealthy cooldown has elapsed."""
+        if not self._endpoint_unhealthy_since:
+            return
+        now = time.monotonic()
+        recovered = [
+            ep
+            for ep, marked_at in self._endpoint_unhealthy_since.items()
+            if now - marked_at >= self._unhealthy_recovery_seconds
+        ]
+        for ep in recovered:
+            self.healthy_endpoints.add(ep)
+            self._endpoint_unhealthy_since.pop(ep, None)
+            logger.info("Re-probing previously unhealthy ColPali endpoint: %s", ep)
 
     async def embed_for_ingestion(self, chunks: Union[Chunk, List[Chunk]]) -> List[MultiVector]:
         ingest_start = time.monotonic()
@@ -131,6 +148,7 @@ class ColpaliApiEmbeddingModel(BaseEmbeddingModel):
         if not indexed_inputs:
             return {}
 
+        self._recover_endpoints()
         # Use healthy endpoints, fall back to all if none healthy
         endpoints = list(self.healthy_endpoints) if self.healthy_endpoints else self.endpoints
         n_endpoints = len(endpoints)
@@ -166,6 +184,7 @@ class ColpaliApiEmbeddingModel(BaseEmbeddingModel):
             elif isinstance(result, Exception):
                 logger.warning(f"Endpoint {endpoint} failed: {result}")
                 self.healthy_endpoints.discard(endpoint)
+                self._endpoint_unhealthy_since[endpoint] = time.monotonic()
                 failed_inputs.extend(batch)
             else:
                 merged.update(result)
@@ -182,6 +201,7 @@ class ColpaliApiEmbeddingModel(BaseEmbeddingModel):
                 # All endpoints failed, reset health and raise
                 logger.error("All ColPali endpoints failed, resetting health status")
                 self.healthy_endpoints = set(self.endpoints)
+                self._endpoint_unhealthy_since.clear()
                 raise RuntimeError(
                     f"All {len(self.endpoints)} ColPali endpoints failed for {len(failed_inputs)} {input_type} inputs"
                 )
@@ -289,6 +309,7 @@ class ColpaliApiEmbeddingModel(BaseEmbeddingModel):
 
     async def embed_for_query(self, text: str) -> MultiVector:
         # Use first healthy endpoint for queries (single text, fast)
+        self._recover_endpoints()
         endpoint = next(iter(self.healthy_endpoints), self.endpoints[0])
         data = await self._call_api_endpoint(endpoint, [text], "text")
         if not data:
@@ -304,6 +325,7 @@ class ColpaliApiEmbeddingModel(BaseEmbeddingModel):
         Returns:
             numpy array of embeddings.
         """
+        self._recover_endpoints()
         endpoint = next(iter(self.healthy_endpoints), self.endpoints[0])
 
         if isinstance(content, Image):


### PR DESCRIPTION
## Summary
- Adds cooldown-based recovery for ColPali API endpoints marked unhealthy by `_embed_inputs_distributed`.
- Previously, a single transient failure permanently removed an endpoint from `healthy_endpoints`, only restored when *all* endpoints failed simultaneously.
- In a multi-endpoint deployment, this could silently leave half (or more) of the embedding capacity idle indefinitely after one transient hiccup.
- Now: failed endpoints enter a 60s cooldown and automatically re-enter rotation when it elapses. If still failing, the existing exception path will put them back in cooldown.

## Behavior change
- **Before**: an endpoint marked unhealthy stays out of rotation until a global reset (all endpoints fail at the same time, or process restart).
- **After**: an endpoint stays out for 60s, then auto-rejoins. Sustained failures naturally cycle back into cooldown — no change to error semantics.

## Implementation
- New instance state: `_endpoint_unhealthy_since: Dict[str, float]` and `_unhealthy_recovery_seconds: float = 60.0`.
- New method `_recover_endpoints()` re-adds endpoints whose cooldown has elapsed.
- Recovery runs at the start of `_embed_inputs_distributed`, `embed_for_query`, and `generate_embeddings`.
- Mark-unhealthy path now records the timestamp; the all-fail reset clears the dict.

## Test plan
- [x] Dry-run covering initial state, no-op recover, recover-within-cooldown, recover-after-cooldown, mixed-state recovery, all-fail reset, and re-marking timer reset.
- [ ] Deploy and soak with multi-endpoint configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)