### PR TITLE
[codex] Handle empty document ingestion gracefully

### DIFF
--- a/core/parser/morphik_parser.py
+++ b/core/parser/morphik_parser.py
@@ -1,8 +1,11 @@
 import io
 import logging
 import os
+import shutil
+import subprocess
 import tempfile
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import openpyxl
@@ -282,6 +285,99 @@ class MorphikParser(BaseParser):
         return ext in self._FAST_EXCEL_EXTENSIONS
 
     @staticmethod
+    def _office_suffix(filename: str) -> Optional[str]:
+        suffix = Path(filename).suffix.lower()
+        if suffix in {".docx", ".doc", ".pptx", ".ppt"}:
+            return suffix
+        return None
+
+    @staticmethod
+    def _convert_office_to_pdf_bytes(file: bytes, suffix: str) -> Optional[bytes]:
+        """Convert Office bytes to PDF bytes for fallback parsing."""
+        if not shutil.which("soffice"):
+            logger.warning("LibreOffice (soffice) not found in PATH; cannot run Office-to-PDF parse fallback.")
+            return None
+
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_input:
+            temp_input.write(file)
+            temp_input_path = temp_input.name
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            try:
+                result = subprocess.run(
+                    [
+                        "soffice",
+                        "--headless",
+                        "--convert-to",
+                        "pdf",
+                        "--outdir",
+                        output_dir,
+                        temp_input_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                )
+                if result.returncode != 0:
+                    logger.warning(
+                        "LibreOffice fallback conversion failed: %s",
+                        result.stderr.strip() or result.stdout.strip(),
+                    )
+                    return None
+
+                pdf_path = Path(output_dir) / f"{Path(temp_input_path).stem}.pdf"
+                if not pdf_path.exists() or pdf_path.stat().st_size == 0:
+                    logger.warning("LibreOffice fallback conversion produced no PDF content")
+                    return None
+
+                return pdf_path.read_bytes()
+            except subprocess.TimeoutExpired:
+                logger.warning("LibreOffice fallback conversion timed out")
+                return None
+            except Exception as e:
+                logger.warning("LibreOffice fallback conversion failed unexpectedly: %s", e)
+                return None
+            finally:
+                try:
+                    os.unlink(temp_input_path)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _build_deep_pdf_converter() -> DocumentConverter:
+        """Build an uncached Docling converter for expensive fallback parsing."""
+        pipeline_options = PdfPipelineOptions()
+        pipeline_options.do_ocr = True
+        pipeline_options.do_table_structure = True
+
+        try:
+            import easyocr  # noqa: F401
+            from docling.datamodel.pipeline_options import EasyOcrOptions
+
+            pipeline_options.ocr_options = EasyOcrOptions(lang=["en"])
+        except Exception as e:
+            logger.info("Could not configure EasyOCR for deep parse fallback: %s", e)
+
+        try:
+            from docling.datamodel.pipeline_options import TableStructureOptions
+
+            pipeline_options.table_structure_options = TableStructureOptions(mode="accurate")
+        except Exception as e:
+            logger.debug("Could not configure accurate table structure for deep parse fallback: %s", e)
+
+        for attr in ("generate_picture_images", "generate_page_images"):
+            if hasattr(pipeline_options, attr):
+                setattr(pipeline_options, attr, True)
+        if hasattr(pipeline_options, "images_scale"):
+            pipeline_options.images_scale = 2.0
+
+        return DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+            }
+        )
+
+    @staticmethod
     def _parse_excel_to_markdown(file: bytes) -> str:
         """Parse XLSX/XLSM to markdown tables using openpyxl directly.
 
@@ -449,6 +545,38 @@ class MorphikParser(BaseParser):
             except OSError:
                 pass
 
+    async def _parse_document_local_deep(self, file: bytes, filename: str) -> str:
+        """Parse document with expensive fallbacks after normal parsing produced no chunks."""
+        parse_file = file
+        parse_filename = filename
+        office_suffix = self._office_suffix(filename)
+        if office_suffix:
+            converted_pdf = self._convert_office_to_pdf_bytes(file, office_suffix)
+            if converted_pdf:
+                parse_file = converted_pdf
+                parse_filename = f"{Path(filename).stem}.pdf"
+
+        suffix = os.path.splitext(parse_filename)[1] or ".pdf"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            temp_file.write(parse_file)
+            temp_path = temp_file.name
+
+        try:
+            converter = self._build_deep_pdf_converter()
+            result = converter.convert(temp_path)
+            text = result.document.export_to_markdown()
+            if not text.strip():
+                self.logger.warning(f"Deep Docling fallback returned no text for {filename}")
+            return text
+        except Exception as e:
+            self.logger.warning(f"Deep Docling fallback failed for {filename}: {e}")
+            return ""
+        finally:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
     async def _parse_document(self, file: bytes, filename: str) -> Tuple[Dict[str, Any], str]:
         """Parse document using Docling (local or API), or read directly for plain text files."""
         # For plain text files, read directly without parsing
@@ -492,6 +620,31 @@ class MorphikParser(BaseParser):
             # Return empty to indicate XML files should use parse_and_chunk_xml
             return {}, ""
         return await self._parse_document(file, filename)
+
+    async def parse_file_to_text_deep(self, file: bytes, filename: str) -> Tuple[Dict[str, Any], str]:
+        """Run an expensive parse fallback after normal parsing produced no usable chunks."""
+        if self._is_plain_text_file(filename):
+            return await self.parse_file_to_text(file, filename)
+
+        parse_file = file
+        parse_filename = filename
+        office_suffix = self._office_suffix(filename)
+        if office_suffix:
+            converted_pdf = self._convert_office_to_pdf_bytes(file, office_suffix)
+            if converted_pdf:
+                parse_file = converted_pdf
+                parse_filename = f"{Path(filename).stem}.pdf"
+
+        if self._parse_api_endpoints:
+            try:
+                text = await self._parse_document_via_api(parse_file, parse_filename)
+                if text.strip():
+                    return {"parse_fallback": "deep"}, text
+            except Exception as e:
+                self.logger.warning(f"Deep API parsing failed, falling back to local: {e}")
+
+        text = await self._parse_document_local_deep(parse_file, parse_filename)
+        return {"parse_fallback": "deep"}, text
 
     async def parse_and_chunk_xml(self, file: bytes, filename: str) -> List[Chunk]:
         """Parse and chunk XML files in one step."""

--- a/core/services/ingestion_service.py
+++ b/core/services/ingestion_service.py
@@ -1520,7 +1520,23 @@ class IngestionService:
 
             try:
                 images = pdf2image.convert_from_bytes(file_content, dpi=dpi)
-                image_payloads = [self.img_to_base64_with_bytes(image) for image in images]
+                image_payloads = []
+                for page_num, image in enumerate(images):
+                    try:
+                        if self._is_blank_image(image):
+                            logger.info(
+                                "Skipping PDF page %d because it rendered as a blank image",
+                                page_num + 1,
+                            )
+                            continue
+                        image_payloads.append(self.img_to_base64_with_bytes(image))
+                    except Exception as page_error:
+                        logger.warning(
+                            "Skipping PDF page %d because image conversion failed: %s",
+                            page_num + 1,
+                            page_error,
+                        )
+                        continue
                 logger.info(f"pdf2image fallback processed {len(image_payloads)} pages")
                 return [
                     self._image_bytes_to_chunk(raw_bytes, mime_type="image/png", base64_override=image_b64)

--- a/core/services/ingestion_service.py
+++ b/core/services/ingestion_service.py
@@ -1301,6 +1301,27 @@ class IngestionService:
         img_str, _ = self.img_to_base64_with_bytes(img)
         return img_str
 
+    @staticmethod
+    def _is_blank_image(img: PILImage.Image, tolerance: int = 2) -> bool:
+        """Return True when an image has no meaningful visual variation."""
+        grayscale = img.convert("L")
+        extrema = grayscale.getextrema()
+        if extrema is None:
+            return True
+        darkest, lightest = extrema
+        return lightest - darkest <= tolerance
+
+    def _is_blank_image_bytes(self, image_bytes: bytes, tolerance: int = 2) -> bool:
+        """Return True when image bytes decode to a visually blank image."""
+        if not image_bytes:
+            return True
+        try:
+            with PILImage.open(BytesIO(image_bytes)) as img:
+                return self._is_blank_image(img, tolerance=tolerance)
+        except Exception as e:
+            logger.warning("Unable to inspect rendered page image for blank-content detection: %s", e)
+            return False
+
     def _render_pdf_with_pymupdf(
         self, file_content: bytes, dpi: int, include_bytes: bool = False
     ) -> List[Union[str, Tuple[str, bytes]]]:
@@ -1308,15 +1329,28 @@ class IngestionService:
         pdf_document = fitz.open("pdf", file_content)
         try:
             images: List[Union[str, Tuple[str, bytes]]] = []
-            for page in pdf_document:
-                mat = fitz.Matrix(dpi / 72, dpi / 72)
-                pix = page.get_pixmap(matrix=mat)
-                png_bytes = pix.tobytes("png")
+            page_count = 0
+            render_failures = 0
+            for page_index, page in enumerate(pdf_document):
+                page_count += 1
+                try:
+                    mat = fitz.Matrix(dpi / 72, dpi / 72)
+                    pix = page.get_pixmap(matrix=mat)
+                    png_bytes = pix.tobytes("png")
+                except Exception as e:
+                    render_failures += 1
+                    logger.warning("Skipping PDF page %d because rendering failed: %s", page_index + 1, e)
+                    continue
+                if self._is_blank_image_bytes(png_bytes):
+                    logger.info("Skipping PDF page %d because it rendered as a blank image", page_index + 1)
+                    continue
                 b64 = bytes_to_data_uri(png_bytes, "image/png")
                 if include_bytes:
                     images.append((b64, png_bytes))
                 else:
                     images.append(b64)
+            if not images and page_count > 0 and render_failures == page_count:
+                raise RuntimeError("All PDF pages failed to render with PyMuPDF")
             return images
         finally:
             pdf_document.close()
@@ -1517,6 +1551,7 @@ class IngestionService:
 
         try:
             total_pages = len(pdf_document)
+            render_failures = 0
             for batch_start in range(0, total_pages, batch_size):
                 batch_end = min(batch_start + batch_size, total_pages)
                 logger.debug(f"Rendering pages {batch_start + 1}-{batch_end} of {total_pages} (batched mode)")
@@ -1524,9 +1559,17 @@ class IngestionService:
                 # Render and convert this batch
                 for page_num in range(batch_start, batch_end):
                     page = pdf_document[page_num]
-                    mat = fitz.Matrix(dpi / 72, dpi / 72)
-                    pix = page.get_pixmap(matrix=mat)
-                    png_bytes = pix.tobytes("png")
+                    try:
+                        mat = fitz.Matrix(dpi / 72, dpi / 72)
+                        pix = page.get_pixmap(matrix=mat)
+                        png_bytes = pix.tobytes("png")
+                    except Exception as e:
+                        render_failures += 1
+                        logger.warning("Skipping PDF page %d because rendering failed: %s", page_num + 1, e)
+                        continue
+                    if self._is_blank_image_bytes(png_bytes):
+                        logger.info("Skipping PDF page %d because it rendered as a blank image", page_num + 1)
+                        continue
                     b64 = bytes_to_data_uri(png_bytes, "image/png")
 
                     # Create chunk immediately
@@ -1536,6 +1579,9 @@ class IngestionService:
                     # Explicitly release pixmap memory - this is the key memory optimization
                     del pix
                     del png_bytes
+
+            if not all_chunks and total_pages > 0 and render_failures == total_pages:
+                raise RuntimeError("All PDF pages failed to render with PyMuPDF")
 
             logger.info(f"PyMuPDF processed {total_pages} pages in batched mode")
             return all_chunks
@@ -1639,19 +1685,41 @@ class IngestionService:
             try:
                 pdf_document = fitz.open("pdf", pdf_content)
                 images_payload: List[Tuple[str, bytes]] = []
+                total_pages = len(pdf_document)
+                render_failures = 0
 
-                for page_num in range(len(pdf_document)):
-                    page = pdf_document[page_num]
-                    dpi = settings.COLPALI_PDF_DPI
-                    mat = fitz.Matrix(dpi / 72, dpi / 72)
-                    pix = page.get_pixmap(matrix=mat)
-                    img_data = pix.tobytes("png")
+                try:
+                    for page_num in range(total_pages):
+                        page = pdf_document[page_num]
+                        try:
+                            dpi = settings.COLPALI_PDF_DPI
+                            mat = fitz.Matrix(dpi / 72, dpi / 72)
+                            pix = page.get_pixmap(matrix=mat)
+                            img_data = pix.tobytes("png")
+                            img = PILImage.open(BytesIO(img_data))
+                            if self._is_blank_image(img):
+                                logger.info(
+                                    "Skipping %s page %d because it rendered as a blank image",
+                                    doc_type,
+                                    page_num + 1,
+                                )
+                                continue
+                            img_str, img_bytes = self.img_to_base64_with_bytes(img)
+                            images_payload.append((img_str, img_bytes))
+                        except Exception as page_error:
+                            render_failures += 1
+                            logger.warning(
+                                "Skipping %s page %d because rendering failed: %s",
+                                doc_type,
+                                page_num + 1,
+                                page_error,
+                            )
+                            continue
+                finally:
+                    pdf_document.close()
 
-                    img = PILImage.open(BytesIO(img_data))
-                    img_str, img_bytes = self.img_to_base64_with_bytes(img)
-                    images_payload.append((img_str, img_bytes))
-
-                pdf_document.close()
+                if not images_payload and total_pages > 0 and render_failures == total_pages:
+                    raise RuntimeError(f"All {doc_type} pages failed to render with PyMuPDF")
 
                 logger.info(f"{doc_type} successfully processed {len(images_payload)} pages as images")
                 return [
@@ -1663,7 +1731,25 @@ class IngestionService:
                 logger.warning(f"PyMuPDF failed for {doc_type} ({pymupdf_error}), trying pdf2image")
                 try:
                     images = pdf2image.convert_from_bytes(pdf_content)
-                    images_payload = [self.img_to_base64_with_bytes(image) for image in images]
+                    images_payload = []
+                    for page_num, image in enumerate(images):
+                        try:
+                            if self._is_blank_image(image):
+                                logger.info(
+                                    "Skipping %s page %d because it rendered as a blank image",
+                                    doc_type,
+                                    page_num + 1,
+                                )
+                                continue
+                            images_payload.append(self.img_to_base64_with_bytes(image))
+                        except Exception as page_error:
+                            logger.warning(
+                                "Skipping %s page %d because image conversion failed: %s",
+                                doc_type,
+                                page_num + 1,
+                                page_error,
+                            )
+                            continue
 
                     logger.info(f"{doc_type} processed {len(images_payload)} pages with pdf2image")
                     return [

--- a/core/tests/unit/test_ingestion_colpali_rendering.py
+++ b/core/tests/unit/test_ingestion_colpali_rendering.py
@@ -1,0 +1,112 @@
+import subprocess
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image
+
+from core.services import ingestion_service as ingestion_module
+from core.services.ingestion_service import IngestionService
+
+
+class FakePixmap:
+    def __init__(self, image_bytes: bytes):
+        self._image_bytes = image_bytes
+
+    def tobytes(self, format: str) -> bytes:
+        assert format == "png"
+        return self._image_bytes
+
+
+class FakePage:
+    def __init__(self, image_bytes: bytes | None = None, error: Exception | None = None):
+        self._image_bytes = image_bytes
+        self._error = error
+
+    def get_pixmap(self, matrix):
+        if self._error:
+            raise self._error
+        return FakePixmap(self._image_bytes or b"")
+
+
+class FakeDocument:
+    def __init__(self, pages):
+        self.pages = pages
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self.pages)
+
+    def __len__(self):
+        return len(self.pages)
+
+    def __getitem__(self, index):
+        return self.pages[index]
+
+    def close(self):
+        self.closed = True
+
+
+def _png_bytes(color: tuple[int, int, int]) -> bytes:
+    image = Image.new("RGB", (12, 12), color)
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _non_blank_png_bytes() -> bytes:
+    image = Image.new("RGB", (12, 12), "white")
+    image.putpixel((5, 5), (0, 0, 0))
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def test_render_pdf_with_pymupdf_skips_blank_and_failed_pages(monkeypatch):
+    service = IngestionService(None, None, None, None, None)
+    fake_document = FakeDocument(
+        [
+            FakePage(_non_blank_png_bytes()),
+            FakePage(error=RuntimeError("bad embedded image")),
+            FakePage(_png_bytes((255, 255, 255))),
+            FakePage(_non_blank_png_bytes()),
+        ]
+    )
+
+    monkeypatch.setattr(ingestion_module.fitz, "open", lambda *args, **kwargs: fake_document)
+
+    rendered_pages = service._render_pdf_with_pymupdf(b"%PDF", dpi=72, include_bytes=True)
+
+    assert len(rendered_pages) == 2
+    assert all(image_b64.startswith("data:image/png;base64,") for image_b64, _ in rendered_pages)
+    assert fake_document.closed is True
+
+
+def test_office_conversion_skips_blank_and_failed_pages(monkeypatch):
+    service = IngestionService(None, None, None, None, None)
+    fake_document = FakeDocument(
+        [
+            FakePage(_non_blank_png_bytes()),
+            FakePage(error=RuntimeError("bad embedded image")),
+            FakePage(_png_bytes((255, 255, 255))),
+            FakePage(_non_blank_png_bytes()),
+        ]
+    )
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/soffice" if name == "soffice" else None)
+    monkeypatch.setattr(ingestion_module.fitz, "open", lambda *args, **kwargs: fake_document)
+
+    def fake_run(cmd, capture_output, text, timeout):
+        output_dir = Path(cmd[cmd.index("--outdir") + 1])
+        input_path = Path(cmd[-1])
+        expected_pdf_path = output_dir / f"{input_path.stem}.pdf"
+        expected_pdf_path.write_bytes(b"%PDF")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    chunks = service._convert_office_to_images(b"pptx-bytes", ".pptx", "PowerPoint presentation", [])
+
+    assert len(chunks) == 2
+    assert all(chunk.metadata["is_image"] is True for chunk in chunks)
+    assert all(chunk.content.startswith("data:image/png;base64,") for chunk in chunks)
+    assert fake_document.closed is True

--- a/core/tests/unit/test_ingestion_colpali_rendering.py
+++ b/core/tests/unit/test_ingestion_colpali_rendering.py
@@ -81,6 +81,37 @@ def test_render_pdf_with_pymupdf_skips_blank_and_failed_pages(monkeypatch):
     assert fake_document.closed is True
 
 
+def test_pdf_pdf2image_fallback_skips_blank_and_failed_pages(monkeypatch):
+    service = IngestionService(None, None, None, None, None)
+    good_page = Image.open(BytesIO(_non_blank_png_bytes()))
+    blank_page = Image.open(BytesIO(_png_bytes((255, 255, 255))))
+    failing_page = Image.open(BytesIO(_non_blank_png_bytes()))
+
+    def fake_img_to_base64_with_bytes(image):
+        if image is failing_page:
+            raise RuntimeError("bad fallback page")
+        return IngestionService.img_to_base64_with_bytes(service, image)
+
+    monkeypatch.setattr(
+        ingestion_module.fitz,
+        "open",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("force pdf2image fallback")),
+    )
+    monkeypatch.setattr(ingestion_module.pdf2image, "convert_from_bytes", lambda *args, **kwargs: [
+        good_page,
+        blank_page,
+        failing_page,
+        good_page,
+    ])
+    monkeypatch.setattr(service, "img_to_base64_with_bytes", fake_img_to_base64_with_bytes)
+
+    chunks = service._process_pdf_for_colpali(b"%PDF")
+
+    assert len(chunks) == 2
+    assert all(chunk.metadata["is_image"] is True for chunk in chunks)
+    assert all(chunk.content.startswith("data:image/png;base64,") for chunk in chunks)
+
+
 def test_office_conversion_skips_blank_and_failed_pages(monkeypatch):
     service = IngestionService(None, None, None, None, None)
     fake_document = FakeDocument(

--- a/core/workers/ingestion_worker.py
+++ b/core/workers/ingestion_worker.py
@@ -5,6 +5,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 import traceback
 import urllib.parse as up
@@ -23,6 +24,7 @@ from core.embedding.colpali_embedding_model import ColpaliEmbeddingModel
 from core.embedding.litellm_embedding import LiteLLMEmbeddingModel
 from core.limits_utils import check_and_increment_limits, estimate_pages_by_chars
 from core.models.auth import AuthContext
+from core.models.chunk import Chunk
 from core.parser.morphik_parser import MorphikParser
 from core.services.ingestion_service import IngestionService, PdfConversionError
 from core.services.telemetry import TelemetryService
@@ -609,8 +611,6 @@ async def process_ingestion_job(
                 )
                 # Clean the extracted text to remove NULL and other problematic control characters
                 # Keep: tabs, newlines, carriage returns, and all printable characters (including Unicode)
-                import re
-
                 # Remove NULL characters
                 text = re.sub(r"\x00", "", text)
                 # Remove control characters (0x00-0x08, 0x0B-0x0C, 0x0E-0x1F) but keep tab, newline, carriage return
@@ -793,9 +793,150 @@ async def process_ingestion_job(
             else:
                 phase_times["multivector_create_chunks"] = 0
 
-            # If we still have no chunks at all (neither text nor image) abort early
+            no_content_extracted = False
+            content_extraction_warning: Optional[str] = None
+
+            if skip_text_parsing and not parsed_chunks and not chunks_multivector:
+                logger.warning(
+                    "No image chunks extracted for ColPali-native document %s (%s). "
+                    "Attempting text extraction fallback before failing ingestion.",
+                    document_id,
+                    original_filename,
+                )
+                fallback_parse_start = time.time()
+                fallback_metadata, fallback_text = await ingestion_service.parser.parse_file_to_text(
+                    file_content, parse_filename
+                )
+
+                fallback_text = re.sub(r"\x00", "", fallback_text)
+                fallback_text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", fallback_text)
+                phase_times["fallback_parse_file"] = time.time() - fallback_parse_start
+
+                if fallback_text.strip():
+                    fallback_chunking_start = time.time()
+                    fallback_chunks = await ingestion_service.parser.split_text(fallback_text)
+                    phase_times["fallback_split_into_chunks"] = time.time() - fallback_chunking_start
+                    if fallback_chunks:
+                        parsed_chunks = fallback_chunks
+                        chunks_multivector = [
+                            Chunk(content=chunk.content, metadata=(chunk.metadata | {"is_image": False}))
+                            for chunk in fallback_chunks
+                        ]
+                        text = fallback_text
+                        additional_metadata = fallback_metadata
+                        fallback_updates = {
+                            "additional_metadata": additional_metadata,
+                            "system_metadata": {"content": text},
+                        }
+                        if end_user_id:
+                            fallback_updates["end_user_id"] = end_user_id
+                        await ingestion_service.db.update_document(
+                            document_id=document_id,
+                            updates=fallback_updates,
+                            auth=auth,
+                        )
+                        refreshed_doc = await ingestion_service.db.get_document(document_id, auth)
+                        if refreshed_doc:
+                            doc = refreshed_doc
+                        logger.info(
+                            "Recovered ColPali-native document %s with %d text chunks after image extraction "
+                            "yielded no chunks",
+                            document_id,
+                            len(parsed_chunks),
+                        )
+                    else:
+                        logger.warning(
+                            "Text fallback for ColPali-native document %s produced no chunks",
+                            document_id,
+                        )
+                else:
+                    logger.warning(
+                        "Text fallback for ColPali-native document %s produced no text",
+                        document_id,
+                    )
+
+            if not parsed_chunks and not chunks_multivector and not xml_processing:
+                deep_parse = getattr(ingestion_service.parser, "parse_file_to_text_deep", None)
+                if callable(deep_parse):
+                    logger.warning(
+                        "No chunks extracted for document %s (%s). Running deep parser fallback.",
+                        document_id,
+                        original_filename,
+                    )
+                    deep_parse_start = time.time()
+                    deep_metadata, deep_text = await deep_parse(file_content, parse_filename)
+                    deep_text = re.sub(r"\x00", "", deep_text)
+                    deep_text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", deep_text)
+                    phase_times["deep_parse_file"] = time.time() - deep_parse_start
+
+                    if deep_text.strip():
+                        deep_chunking_start = time.time()
+                        deep_chunks = await ingestion_service.parser.split_text(deep_text)
+                        phase_times["deep_split_into_chunks"] = time.time() - deep_chunking_start
+                        if deep_chunks:
+                            parsed_chunks = deep_chunks
+                            if using_colpali:
+                                chunks_multivector = [
+                                    Chunk(content=chunk.content, metadata=(chunk.metadata | {"is_image": False}))
+                                    for chunk in deep_chunks
+                                ]
+                            text = deep_text
+                            additional_metadata = deep_metadata
+                            deep_updates = {
+                                "additional_metadata": additional_metadata,
+                                "system_metadata": {
+                                    "content": text,
+                                    "content_extraction_status": "deep_fallback_succeeded",
+                                    "content_extraction_warning": None,
+                                },
+                            }
+                            if end_user_id:
+                                deep_updates["end_user_id"] = end_user_id
+                            await ingestion_service.db.update_document(
+                                document_id=document_id,
+                                updates=deep_updates,
+                                auth=auth,
+                            )
+                            refreshed_doc = await ingestion_service.db.get_document(document_id, auth)
+                            if refreshed_doc:
+                                doc = refreshed_doc
+                            logger.info(
+                                "Recovered document %s with %d text chunks using deep parser fallback",
+                                document_id,
+                                len(parsed_chunks),
+                            )
+                        else:
+                            logger.warning("Deep parser fallback for document %s produced no chunks", document_id)
+                    else:
+                        logger.warning("Deep parser fallback for document %s produced no text", document_id)
+
+            # If we still have no chunks at all, accept the document but mark it as non-searchable.
             if not parsed_chunks and not chunks_multivector:
-                raise ValueError("No content chunks (text or image) could be extracted from the document")
+                no_content_extracted = True
+                content_extraction_warning = (
+                    "No content chunks (text or image) could be extracted from the document. "
+                    "The document was saved successfully but will not be searchable until content can be extracted."
+                )
+                logger.warning(
+                    "%s document_id=%s filename=%s",
+                    content_extraction_warning,
+                    document_id,
+                    original_filename,
+                )
+                await ingestion_service.db.update_document(
+                    document_id=document_id,
+                    updates={
+                        "system_metadata": {
+                            "content_extraction_status": "no_content_extracted",
+                            "content_extraction_warning": content_extraction_warning,
+                            "content": text,
+                        }
+                    },
+                    auth=auth,
+                )
+                refreshed_doc = await ingestion_service.db.get_document(document_id, auth)
+                if refreshed_doc:
+                    doc = refreshed_doc
 
             # Determine the final page count for recording usage
             final_page_count = num_pages_estimated  # Default to estimate
@@ -1151,6 +1292,9 @@ async def process_ingestion_job(
                 "updated_at": doc.system_metadata["updated_at"],
                 "progress": None,
             }
+            if no_content_extracted:
+                completion_update["content_extraction_status"] = "no_content_extracted"
+                completion_update["content_extraction_warning"] = content_extraction_warning
             await ingestion_service.db.update_document(
                 document_id=document_id, updates={"system_metadata": completion_update}, auth=auth
             )
@@ -1245,6 +1389,7 @@ async def process_ingestion_job(
                 {
                     "xml_processing": xml_processing,
                     "html_to_pdf": html_converted,
+                    "no_content_extracted": no_content_extracted,
                 }
             )
 


### PR DESCRIPTION
This PR makes document ingestion tolerant of blank or unextractable pages by skipping blank/failed rendered pages while preserving valid pages for ColPali. It adds a deep parser fallback that retries empty text extraction with Office-to-PDF conversion and OCR-oriented Docling settings before giving up. If no text or image chunks can still be extracted, ingestion now completes with explicit non-searchable metadata instead of failing the whole document. Validation: `python3.11 -m py_compile core/parser/morphik_parser.py core/workers/ingestion_worker.py core/services/ingestion_service.py core/tests/unit/test_ingestion_colpali_rendering.py` and `git diff --check`; targeted pytest remains blocked by the local morphik-rust/Python environment issue.