### PR TITLE
Validate text ingest content

### DIFF
--- a/core/models/request.py
+++ b/core/models/request.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Type, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from core.models.completion import ChunkSource
 from core.models.documents import Document
@@ -227,6 +227,7 @@ class IngestTextRequest(BaseModel):
 
     content: str = Field(
         ...,
+        min_length=1,
         description="Raw text content to store as a document.",
     )
     filename: Optional[str] = Field(
@@ -247,6 +248,13 @@ class IngestTextRequest(BaseModel):
     )
     folder_name: Optional[str] = Field(None, description="Optional folder scope for the operation")
     end_user_id: Optional[str] = Field(None, description="Optional end-user scope for the operation")
+
+    @field_validator("content")
+    @classmethod
+    def validate_content_not_blank(cls, content: str) -> str:
+        if not content.strip():
+            raise ValueError("content must not be empty")
+        return content
 
 
 class MetadataUpdateRequest(BaseModel):

--- a/core/tests/unit/test_request_models.py
+++ b/core/tests/unit/test_request_models.py
@@ -1,0 +1,20 @@
+"""Unit tests for API request models."""
+
+import pytest
+from pydantic import ValidationError
+
+from core.models.request import IngestTextRequest
+
+
+class TestIngestTextRequest:
+    """Tests for text ingestion request validation."""
+
+    @pytest.mark.parametrize("content", ["", "   ", "\n\t"])
+    def test_rejects_empty_content(self, content):
+        with pytest.raises(ValidationError):
+            IngestTextRequest(content=content)
+
+    def test_accepts_non_empty_content(self):
+        request = IngestTextRequest(content="hello world")
+
+        assert request.content == "hello world"


### PR DESCRIPTION
Reject empty or whitespace-only text ingestion payloads at the IngestTextRequest validation layer before they can be queued and fail later with a 500. This fixes the root cause by enforcing non-empty content for both /ingest/text and text document updates, since both use the shared request model. Added focused unit coverage for empty, whitespace-only, and valid text payloads. Validation used: uv run --no-project --with pytest --with pydantic --with pillow --with numpy --with fastapi pytest core/tests/unit/test_request_models.py.