### PR TITLE
fix: reject non-finite numeric metadata supplied as strings

### DIFF
--- a/core/tests/unit/test_typed_metadata.py
+++ b/core/tests/unit/test_typed_metadata.py
@@ -157,6 +157,18 @@ class TestNormalizeMetadata:
         with pytest.raises(TypedMetadataError, match="cannot store NaN or infinite"):
             _normalize_values({"value": float("inf")}, {"value": "number"})
 
+    def test_number_coercion_rejects_nan_and_infinity_strings(self):
+        """Non-finite values supplied as strings must be rejected too.
+
+        Regression: the string branch parsed "inf"/"nan" (and overflowing
+        literals like "1e400") into non-finite floats without the finite check
+        applied to numeric inputs, letting them through to storage where they
+        break JSON serialization and Postgres double precision columns.
+        """
+        for token in ("inf", "-inf", "Infinity", "nan", "1e400"):
+            with pytest.raises(TypedMetadataError, match="cannot store NaN or infinite"):
+                _normalize_values({"value": token}, {"value": "number"})
+
     def test_decimal_coercion(self):
         """Test decimal coercion from various types."""
         metadata = {

--- a/core/utils/typed_metadata.py
+++ b/core/utils/typed_metadata.py
@@ -238,9 +238,12 @@ def _coerce_number(value: Any, field: str) -> int | float:
         try:
             if all(ch.isdigit() or ch in {"+", "-", "_"} for ch in text.replace("_", "")) and "." not in text:
                 return int(text.replace("_", ""))
-            return float(text)
+            parsed = float(text)
         except ValueError as exc:  # noqa: BLE001
             raise TypedMetadataError(f"Metadata field '{field}' expects a numeric value.") from exc
+        if math.isnan(parsed) or math.isinf(parsed):
+            raise TypedMetadataError(f"Metadata field '{field}' cannot store NaN or infinite values.")
+        return parsed
 
     raise TypedMetadataError(f"Metadata field '{field}' expects a numeric value.")
 


### PR DESCRIPTION
## Bug

`typed_metadata._coerce_number` is used by `normalize_metadata` / `merge_metadata` to coerce user-supplied document metadata according to a declared type. For numeric inputs it explicitly rejects NaN/infinite values:

```python
if isinstance(value, (int, float)) and not isinstance(value, bool):
    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
        raise TypedMetadataError(f"Metadata field '{field}' cannot store NaN or infinite values.")
    return value
```

…because those values break JSON serialization (`json.dumps(float('inf'))` emits `Infinity`, which is invalid JSON) and Postgres `double precision` storage. But the **string** branch did not apply the same guard:

```python
return float(text)
```

So when a field is declared as `number` (or an alias like `int`/`float`) and the value arrives as a string, `"inf"`, `"-inf"`, `"Infinity"`, `"nan"`, and overflowing literals such as `"1e400"` (Python parses this to `inf`) were coerced into non-finite floats and stored, corrupting the document row at write time. Metadata and type hints both come straight from the ingestion request body (see `core/services/v2_document_service.py` and `core/services/ingestion_service.py`), so this is reachable from a normal API call.

## Reproduction

```python
from core.utils.typed_metadata import normalize_metadata
bundle = normalize_metadata({"score": "inf"}, {"score": "number"})
print(bundle.values["score"])   # inf  -> later breaks json.dumps / Postgres insert
```

## Fix

Apply the existing finite-value check to the parsed string result, raising the same `TypedMetadataError` the numeric path uses. Four lines added, one changed; valid numeric strings (including scientific notation like `"1e5"`) are unaffected.

## Regression test

Extended `test_number_coercion_rejects_nan_and_infinity` with a string-input case (`test_number_coercion_rejects_nan_and_infinity_strings`) covering `inf`, `-inf`, `Infinity`, `nan`, and `1e400`. It **fails before** the fix (`DID NOT RAISE`) and **passes after**. Full `test_typed_metadata.py` suite stays green (47 passed).

```
$ pytest core/tests/unit/test_typed_metadata.py -q
47 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)