### PR TITLE
[codex] Bump Python SDK to 1.2.4

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-06-18
+
+### Added
+- Migration helpers for copying documents between Morphik deployments:
+  - `Morphik.migrate(target_uri=...)`
+  - `AsyncMorphik.migrate(target_uri=...)`
+- Migration result models with per-document created/skipped/failed status.
+
+### Fixed
+- Migration ingestion now aborts if the initial document metadata record cannot be created.
+
 ## [1.2.3] - 2026-06-18
 
 ### Added

--- a/sdks/python/morphik/__init__.py
+++ b/sdks/python/morphik/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "MigrationResult",
 ]
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "morphik"
-version = "1.2.3"
+version = "1.2.4"
 authors = [
     { name = "Morphik", email = "founders@morphik.ai" },
 ]


### PR DESCRIPTION
Bumps the Python SDK package metadata from 1.2.3 to 1.2.4 and records the migration helper release in the SDK changelog.

The 1.2.4 package has already been published to PyPI: https://pypi.org/project/morphik/1.2.4/

Validation: `uv run python -m build`, `uv run twine check dist/*`, and `python3 -m pip index versions morphik --no-cache-dir`.