### PR TITLE
Bump Python SDK to 1.2.5 (re-publish with field projection + migrate)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5] - 2026-06-19
+
+### Fixed
+- Re-publish from a complete source tree. The 1.2.4 artifact on PyPI was built from a stale
+  checkout and was missing `list_documents(fields=[...])` (added in 1.2.3). 1.2.5 ships the full
+  source — field projection and the migration helpers together.
+
 ## [1.2.4] - 2026-06-18
 
 ### Added

--- a/sdks/python/morphik/__init__.py
+++ b/sdks/python/morphik/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "MigrationResult",
 ]
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "morphik"
-version = "1.2.4"
+version = "1.2.5"
 authors = [
     { name = "Morphik", email = "founders@morphik.ai" },
 ]


### PR DESCRIPTION
## Summary

Bumps the Python SDK to **1.2.5** and republishes to PyPI.

The `1.2.4` artifact on PyPI was built from a stale local checkout and shipped **without** `list_documents(fields=[...])` (added in 1.2.3) — so `pip install -U morphik` regressed that feature for users. `main` itself was always correct (it has both field projection and the migration helpers); only the published artifact was incomplete.

`1.2.5` is built from current `main`, so it ships the full source: **field projection + migration helpers together**.

## Verification

- Built from current `main`; wheel contains `list_documents(fields=...)` (sync+async), the `metadata_types` typed-reconstruction fix, and `migrate()` on both clients.
- 49 SDK unit tests pass against the installed wheel; `fields` request-building exercised functionally.
- Published and confirmed: a fresh `pip install morphik==1.2.5` from PyPI exposes both `fields` and `migrate`.

## Follow-up (process)

The 1.2.4 PyPI artifact diverged from `main` because it was built from a stale checkout. Recommend publishing only after `git checkout main && git pull` — or moving publishing to a CI job triggered on a version tag so the artifact always matches `main`. The stale `1.2.4` can optionally be yanked on PyPI (it silently dropped a feature 1.2.3 had).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
