### PR TITLE
Read document status from a local snapshot (fix is_* N+1) — SDK 1.2.6

### DIFF
--- a/core/database/postgres_database.py
+++ b/core/database/postgres_database.py
@@ -65,6 +65,11 @@ DOCUMENT_PROJECTION_ORDER = [
     "app_id",
     "end_user_id",
 ]
+# Lightweight scalar keys inside system_metadata that can be projected cheaply via a
+# JSON-path read (system_metadata->>'<key>'), without materializing the full
+# system_metadata blob (which holds the document text). Returned in a slim
+# system_metadata dict so the SDK can read e.g. doc status locally with no extra call.
+DOCUMENT_STATUS_PROJECTION_KEYS = {"status", "error", "created_at", "updated_at", "progress", "version"}
 
 
 class PostgresDatabase:
@@ -629,9 +634,10 @@ class PostgresDatabase:
     def _resolve_document_projection_fields(fields: Optional[List[str]]) -> Optional[set]:
         """Resolve requested API fields to the document table columns needed to serve them.
 
-        Note: ``summary_*`` and ``page_count`` are derived from ``system_metadata``, so
-        projecting them reads that column (which also holds the full document text). Plain
-        ``metadata`` lives in its own column and stays lightweight.
+        Lightweight status keys (``status``, ``error``, timestamps) are projected via a cheap
+        JSON-path read of ``system_metadata`` rather than the full column, so they do not pull
+        the document text. ``summary_*`` and ``page_count`` are derived from the full
+        ``system_metadata`` column. Plain ``metadata`` lives in its own column and stays light.
         """
         if not fields:
             return None
@@ -645,8 +651,11 @@ class PostgresDatabase:
         for root in requested_roots:
             if root in DOCUMENT_PROJECTION_COLUMN_MAP:
                 resolved_fields.add(root)
+            elif root in DOCUMENT_STATUS_PROJECTION_KEYS:
+                # Cheap JSON-path read of a single system_metadata key (no full blob).
+                resolved_fields.add(f"sm:{root}")
             elif root in SUMMARY_METADATA_KEYS:
-                # summary_* values are derived from system_metadata.
+                # summary_* values are derived from the full system_metadata column.
                 resolved_fields.add("system_metadata")
             elif root == "page_count":
                 resolved_fields.add("system_metadata")
@@ -657,14 +666,34 @@ class PostgresDatabase:
     @staticmethod
     def _document_projection_columns(fields: set):
         """Return a stable list of labeled SQLAlchemy columns for a document projection."""
-        return [
+        columns = [
             DOCUMENT_PROJECTION_COLUMN_MAP[field].label(field) for field in DOCUMENT_PROJECTION_ORDER if field in fields
         ]
+        # Cheap per-key JSON-path reads for lightweight system_metadata scalars.
+        for field in sorted(f for f in fields if isinstance(f, str) and f.startswith("sm:")):
+            key = field[len("sm:") :]
+            columns.append(DocumentModel.system_metadata[key].astext.label(f"__sm_{key}"))
+        return columns
 
     @staticmethod
     def _document_projection_row_to_dict(row: Any, fields: set) -> Dict[str, Any]:
         """Convert a projected document row (a SQLAlchemy mapping) to the public document dict shape."""
         document = dict(row)
+
+        # Reassemble cheaply-projected system_metadata scalars (labeled __sm_<key>) into a
+        # slim system_metadata dict so the public shape matches a full document.
+        status_keys = {f[len("sm:") :] for f in fields if isinstance(f, str) and f.startswith("sm:")}
+        if status_keys:
+            slim = {}
+            for key in status_keys:
+                label = f"__sm_{key}"
+                if label in document:
+                    slim[key] = document.pop(label)
+            existing = document.get("system_metadata")
+            if isinstance(existing, dict):
+                existing.update(slim)
+            else:
+                document["system_metadata"] = slim
 
         for key in ("metadata", "metadata_types", "storage_info", "system_metadata", "additional_metadata"):
             if key in document and document[key] is None:

--- a/core/routes/utils.py
+++ b/core/routes/utils.py
@@ -35,6 +35,12 @@ def _add_derived_fields(document_dict: Dict[str, Any]) -> Dict[str, Any]:
     return enriched
 
 
+# Lightweight processing-state keys that live under system_metadata. When requested as a
+# top-level field (e.g. "status"), project the corresponding system_metadata.<key> so the
+# value survives in the slim system_metadata the SDK reads locally.
+_STATUS_ALIAS_KEYS = {"status", "error", "created_at", "updated_at", "progress", "version"}
+
+
 def project_document_fields(document_dict: Dict[str, Any], fields: Optional[List[str]]) -> Dict[str, Any]:
     """
     Project document data to a subset of fields, always including the external_id for reference.
@@ -45,7 +51,11 @@ def project_document_fields(document_dict: Dict[str, Any], fields: Optional[List
         return document_dict
 
     projected: Dict[str, Any] = {}
-    normalized_fields: List[str] = [field.strip() for field in fields if field and field.strip()]
+    normalized_fields: List[str] = [
+        f"system_metadata.{field.strip()}" if field.strip() in _STATUS_ALIAS_KEYS else field.strip()
+        for field in fields
+        if field and field.strip()
+    ]
     include_external_id = "external_id" in normalized_fields
 
     for field_path in normalized_fields:

--- a/core/tests/unit/test_document_projection.py
+++ b/core/tests/unit/test_document_projection.py
@@ -53,6 +53,34 @@ class TestProjectionColumns:
         assert "system_metadata" not in sql
 
 
+class TestStatusProjection:
+    """Lightweight `status` projection reads only a JSON-path, not the full blob."""
+
+    def test_status_resolves_to_cheap_json_path(self):
+        resolved = PostgresDatabase._resolve_document_projection_fields(["status"])
+        assert "sm:status" in resolved
+        assert "external_id" in resolved
+        assert "system_metadata" not in resolved  # never the full column
+
+    def test_status_sql_uses_json_path(self):
+        resolved = PostgresDatabase._resolve_document_projection_fields(["external_id", "status"])
+        sql = str(select(*PostgresDatabase._document_projection_columns(resolved)))
+        assert "system_metadata ->>" in sql
+        assert "__sm_status" in sql
+
+    def test_row_reassembles_slim_system_metadata(self):
+        resolved = PostgresDatabase._resolve_document_projection_fields(["status", "error"])
+        row = {"external_id": "d1", "__sm_status": "completed", "__sm_error": None}
+        out = PostgresDatabase._document_projection_row_to_dict(row, resolved)
+        assert out["system_metadata"]["status"] == "completed"
+        assert "__sm_status" not in out
+
+    def test_app_layer_projection_keeps_status(self):
+        doc = {"external_id": "d1", "system_metadata": {"status": "completed"}}
+        out = project_document_fields(doc, ["external_id", "status"])
+        assert out["system_metadata"] == {"status": "completed"}
+
+
 class TestProjectionRowToDict:
     """PostgresDatabase._document_projection_row_to_dict."""
 

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-06-19
+
+### Changed
+- `Document` status is now a local snapshot read instead of a per-access API call.
+  `Document.status` / `is_processing` / `is_ingested` / `is_failed` / `error` read the status
+  already carried on the document (`system_metadata`), eliminating an N+1 when iterating
+  documents (previously each `is_*` access made its own request). `status` now also returns
+  `as_of` (when the snapshot was pulled) and `source` (`"local"` / `"not_loaded"`). If status
+  was not fetched (e.g. projected away), `is_*` return `False` and make **no** network call.
+  Use `Document.refresh()` or `wait_for_completion()` for the current live status.
+
+### Added
+- `Document.refresh()` — re-fetch a document from the server to get its current status.
+- `status` is now a cheap, projectable field: `list_documents(fields=[..., "status"])` returns
+  the processing status (and `error`/timestamps) via a JSON-path read — without downloading the
+  full document text — so `is_*` resolve locally with zero extra calls.
+
 ## [1.2.5] - 2026-06-19
 
 ### Fixed

--- a/sdks/python/morphik/__init__.py
+++ b/sdks/python/morphik/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "MigrationResult",
 ]
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/sdks/python/morphik/models.py
+++ b/sdks/python/morphik/models.py
@@ -1,9 +1,9 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, BinaryIO, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 
 def _reconstruct_metadata_types(metadata: Dict[str, Any], metadata_types: Dict[str, str]) -> Dict[str, Any]:
@@ -74,6 +74,8 @@ class Document(BaseModel):
 
     # Client reference for update methods
     _client = None
+    # When this document snapshot was pulled from the server (UTC), set at construction.
+    _fetched_at: Optional[datetime] = PrivateAttr(default_factory=lambda: datetime.now(timezone.utc))
 
     @model_validator(mode="after")
     def _reconstruct_types(self) -> "Document":
@@ -85,37 +87,95 @@ class Document(BaseModel):
 
     @property
     def status(self) -> Dict[str, Any]:
-        """Get the latest processing status of the document from the API.
+        """Processing status of the document **as of when it was fetched** (a snapshot).
 
-        Returns:
-            Dict[str, Any]: Status information including current status, potential errors, and other metadata
+        This reads the status already carried on the document (in ``system_metadata``) and
+        does **not** make a network call. The returned dict includes:
+
+        - ``status``: ``processing`` / ``completed`` / ``failed`` (or ``unknown``)
+        - ``error``: error message when ``status == "failed"``
+        - ``created_at`` / ``updated_at``: server timestamps for the document
+        - ``as_of``: ISO-8601 timestamp of when this snapshot was pulled from the server
+        - ``source``: ``"local"`` (read from the document) or ``"not_loaded"``
+
+        If the document was fetched with a field projection that excluded the status
+        (e.g. ``list_documents(fields=["metadata"])`` without ``"status"``), there is no
+        local status and this returns ``status="unknown"`` / ``source="not_loaded"`` —
+        **it does not make a network call.** To include status cheaply in a projection,
+        add ``"status"`` to ``fields``; for the *current* live status, call :meth:`refresh`
+        or :meth:`wait_for_completion` instead of re-reading this property in a loop.
+        """
+        sm = self.system_metadata or {}
+        if "status" in sm:
+            return {
+                "document_id": self.external_id,
+                "status": sm.get("status"),
+                "error": sm.get("error"),
+                "created_at": sm.get("created_at"),
+                "updated_at": sm.get("updated_at"),
+                "as_of": self._fetched_at.isoformat() if self._fetched_at else sm.get("updated_at"),
+                "source": "local",
+            }
+        # Status was not fetched with this document (e.g. projected away). Do not silently
+        # make a per-document API call — report it as not loaded.
+        return {
+            "document_id": self.external_id,
+            "status": "unknown",
+            "error": None,
+            "as_of": self._fetched_at.isoformat() if self._fetched_at else None,
+            "source": "not_loaded",
+        }
+
+    @property
+    def is_processing(self) -> bool:
+        """True if the document was still processing **as of when it was fetched** (snapshot).
+
+        See :attr:`status`. Returns ``False`` if status was not loaded (projected away). Use
+        :meth:`refresh` / :meth:`wait_for_completion` for the current state.
+        """
+        return self.status.get("status") == "processing"
+
+    @property
+    def is_ingested(self) -> bool:
+        """True if the document had completed processing **as of when it was fetched** (snapshot).
+
+        See :attr:`status`. Returns ``False`` if status was not loaded (projected away). Use
+        :meth:`refresh` / :meth:`wait_for_completion` for the current state.
+        """
+        return self.status.get("status") == "completed"
+
+    @property
+    def is_failed(self) -> bool:
+        """True if document processing had failed **as of when it was fetched** (snapshot).
+
+        See :attr:`status`. Returns ``False`` if status was not loaded (projected away). Use
+        :meth:`refresh` for the current state.
+        """
+        return self.status.get("status") == "failed"
+
+    @property
+    def error(self) -> Optional[str]:
+        """Error message if processing had failed (snapshot; see :attr:`status`)."""
+        status_info = self.status
+        return status_info.get("error") if status_info.get("status") == "failed" else None
+
+    def refresh(self) -> "Document":
+        """Re-fetch this document from the server and return the updated snapshot.
+
+        Use this (or :meth:`wait_for_completion`) when you need the *current* status rather
+        than the snapshot carried on this object::
+
+            doc = doc.refresh()
+            if doc.is_ingested:
+                ...
+
+        Requires a document returned from a Morphik client method.
         """
         if self._client is None:
             raise ValueError(
                 "Document instance not connected to a client. Use a document returned from a Morphik client method."
             )
-        return self._client.get_document_status(self.external_id)
-
-    @property
-    def is_processing(self) -> bool:
-        """Check if the document is still being processed."""
-        return self.status.get("status") == "processing"
-
-    @property
-    def is_ingested(self) -> bool:
-        """Check if the document has completed processing."""
-        return self.status.get("status") == "completed"
-
-    @property
-    def is_failed(self) -> bool:
-        """Check if document processing has failed."""
-        return self.status.get("status") == "failed"
-
-    @property
-    def error(self) -> Optional[str]:
-        """Get the error message if processing failed."""
-        status_info = self.status
-        return status_info.get("error") if status_info.get("status") == "failed" else None
+        return self._client.get_document(self.external_id)
 
     def wait_for_completion(self, timeout_seconds=300, check_interval_seconds=2, progress_callback=None):
         """Wait for document processing to complete.

--- a/sdks/python/morphik/tests/test_document_status.py
+++ b/sdks/python/morphik/tests/test_document_status.py
@@ -1,0 +1,77 @@
+"""Document status is a local snapshot read — no per-access network calls."""
+
+import pytest
+from morphik.models import Document
+
+
+def test_status_reads_local_snapshot_without_a_call():
+    doc = Document(
+        external_id="d1",
+        content_type="text/plain",
+        system_metadata={"status": "failed", "error": "boom", "updated_at": "2026-06-01T00:00:00"},
+    )
+    snap = doc.status
+    assert snap["status"] == "failed"
+    assert snap["error"] == "boom"
+    assert snap["source"] == "local"
+    assert snap["as_of"]  # stamped at construction
+    assert doc.is_failed and not doc.is_processing and not doc.is_ingested
+    assert doc.error == "boom"
+
+
+def test_status_not_loaded_makes_no_call():
+    # Status projected away (no system_metadata) and no client attached: must not call out.
+    doc = Document(external_id="d2", content_type="text/plain", metadata={"a": 1})
+    snap = doc.status
+    assert snap["status"] == "unknown"
+    assert snap["source"] == "not_loaded"
+    assert doc.is_failed is False
+    assert doc.is_processing is False
+    assert doc.is_ingested is False
+
+
+def test_projected_status_is_read_locally():
+    # Shape the server returns for list_documents(fields=[..., "status"]).
+    doc = Document(external_id="d3", content_type="text/plain", system_metadata={"status": "completed"})
+    assert doc.is_ingested
+    assert doc.status["source"] == "local"
+
+
+def test_refresh_requires_client():
+    doc = Document(external_id="d4", content_type="text/plain")
+    with pytest.raises(ValueError):
+        doc.refresh()
+
+
+class _CountingClient:
+    """Records any status/document fetch so tests can assert zero calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get_document_status(self, *args, **kwargs):
+        self.calls.append("get_document_status")
+        return {"status": "processing"}
+
+    def get_document(self, *args, **kwargs):
+        self.calls.append("get_document")
+        return None
+
+
+def test_is_star_make_zero_client_calls_when_status_local():
+    # Regression guard for the N+1: reading status/is_* on a document that already carries
+    # its status must NOT make any client call, even with a client attached.
+    doc = Document(external_id="d5", content_type="text/plain", system_metadata={"status": "completed"})
+    client = _CountingClient()
+    doc._client = client
+    _ = (doc.status, doc.is_failed, doc.is_processing, doc.is_ingested, doc.error)
+    assert client.calls == [], f"is_*/status must make zero client calls, made: {client.calls}"
+
+
+def test_is_star_make_zero_calls_when_not_loaded_even_with_client():
+    doc = Document(external_id="d6", content_type="text/plain")  # status not loaded
+    client = _CountingClient()
+    doc._client = client
+    _ = (doc.is_failed, doc.is_processing, doc.is_ingested)
+    assert client.calls == [], f"not-loaded status must make zero calls, made: {client.calls}"
+    assert doc.status["source"] == "not_loaded"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "morphik"
-version = "1.2.5"
+version = "1.2.6"
 authors = [
     { name = "Morphik", email = "founders@morphik.ai" },
 ]


### PR DESCRIPTION
## Summary

Fixes an N+1 in the SDK: reading `Document.is_failed` / `is_processing` / `is_ingested` / `status` / `error` made a `get_document_status` **API call on every access**, so building a list of dicts over N documents fired ~3N extra requests — erasing the speed win from field projection.

Now these read the status the document **already carries** (`system_metadata`) — **zero network calls**. Measured against a live server: 0 extra calls for 50 docs (was ~150).

## Changes

**SDK (`models.py`)**
- `status` / `is_*` / `error` read local `system_metadata` instead of calling the server.
- `status` returns `as_of` (when the snapshot was pulled) and `source` (`"local"` / `"not_loaded"`). If status wasn't fetched (e.g. projected away), `is_*` return `False` and make **no** call.
- New `Document.refresh()` for an explicit live re-fetch; docstrings point to `refresh()` / `wait_for_completion()` for the current status.

**Server (`postgres_database.py`, `routes/utils.py`)**
- `status` (and `error`/timestamps) is now a cheap projectable field: `list_documents(fields=[..., "status"])` reads `system_metadata->>'status'` via JSON-path (no document text) and returns it in a slim `system_metadata`, so `is_*` resolve locally with zero extra calls.

**Release**: bump SDK to **1.2.6** (published to PyPI), CHANGELOG updated.

## Behavior note

`status` / `is_*` now reflect the document **as fetched** (a snapshot), not a live value. Polling via `while doc.is_processing:` should use `doc.wait_for_completion()` (unchanged — it re-fetches) or the new `doc.refresh()`.

## Tests

- SDK: `test_document_status.py` incl. a **call-counting regression guard** asserting `is_*` make zero client calls (the gap that let this bug through).
- Server: `test_document_projection.py` — `status` resolves to a JSON-path (not the full blob), slim `system_metadata` reassembly, app-layer projection keeps it.
- Full core unit suite green; live e2e confirms 0 extra calls. `wait_for_completion` verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
