### PR TITLE
docs: correct SDK live-test commands and URI guidance

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -169,6 +169,10 @@ pip install -r test_requirements.txt
 
 Then run the tests:
 
+These live tests mutate server state and may leave residual folders or scoped
+artifacts behind. Run them only against a local or disposable test server or
+tenant, never against production or shared data.
+
 ```bash
 # Run all tests (requires a running Morphik server)
 pytest morphik/tests/ -v
@@ -180,20 +184,24 @@ pytest morphik/tests/test_async.py -v
 # Skip tests if you don't have a running server
 SKIP_LIVE_TESTS=1 pytest morphik/tests/ -v
 
-# Specify a custom server URL for tests
-MORPHIK_TEST_URL=http://custom-server:8000 pytest morphik/tests/ -v
+# Specify a custom disposable test server URI
+# Use direct http(s) endpoints inline; source credential-bearing morphik:// URIs
+# from a local secret store or uncommitted env file instead of shell history or CI logs
+MORPHIK_TEST_URI=http://custom-server:8000 pytest morphik/tests/ -v
 ```
 
 ### Example Usage Script
 
-The SDK comes with an example script that demonstrates basic usage:
+The SDK comes with an example script that demonstrates basic usage. It creates
+server data and only partially cleans it up, so run it only against a local or
+disposable test environment.
 
 ```bash
 # Run synchronous example
-python -m morphik.tests.example_usage
+uv run python -m morphik.tests.example_usage
 
 # Run asynchronous example
-python -m morphik.tests.example_usage --async
+uv run python -m morphik.tests.example_usage --run-async
 ```
 
 The example script demonstrates:

--- a/sdks/python/morphik/tests/README.md
+++ b/sdks/python/morphik/tests/README.md
@@ -15,27 +15,37 @@ This directory contains tests and example code for the Morphik SDK.
 
 ## Running Tests
 
+These live tests mutate server state and may leave residual folders or scoped
+artifacts behind. Run them only against a local or disposable test server or
+tenant, never against production or shared data.
+
 ```bash
-# Using default localhost:8000 URL
+# Using default localhost:8000 server URI
 pytest test_sync.py test_async.py -v
 
 # Tests connect to localhost:8000 by default
-# No need to specify a URL unless you want to test against a different server
+# No need to specify a URI unless you want to test against a different server
 
-# With a custom server URL (optional)
-MORPHIK_TEST_URL=http://custom-url:8000 pytest test_sync.py -v
+# With a custom disposable test server URI (optional; applies to sync and async tests)
+# Use direct http(s) endpoints inline; source credential-bearing morphik:// URIs
+# from a local secret store or uncommitted env file instead of shell history or CI logs
+MORPHIK_TEST_URI=http://custom-url:8000 pytest test_sync.py test_async.py -v
 ```
 
 ### Example Usage Script
-```bash
-# Run synchronous example
-python example_usage.py
 
-# Run asynchronous example
-python example_usage.py --async
+The example script creates server data and only partially cleans it up. Run it
+only against the same local or disposable test environment.
+
+```bash
+# Run synchronous example from this directory
+PYTHONPATH=../.. uv run python example_usage.py
+
+# Run asynchronous example from this directory
+PYTHONPATH=../.. uv run python example_usage.py --run-async
 ```
 
 ## Environment Variables
 
-- `MORPHIK_TEST_URL` - The URL of the Morphik server to use for tests (default: http://localhost:8000)
+- `MORPHIK_TEST_URI` - The Morphik server URI to use for tests; accepts direct `http(s)://` endpoints or authenticated `morphik://` URIs (default: http://localhost:8000)
 - `SKIP_LIVE_TESTS` - Set to "1" to skip tests that require a running server

--- a/sdks/python/morphik/tests/example_usage.py
+++ b/sdks/python/morphik/tests/example_usage.py
@@ -4,10 +4,10 @@ Example script demonstrating basic usage of the Morphik SDK.
 This can be run to verify that the SDK is working correctly.
 
 Usage:
-    python example_usage.py [--async]
+    uv run python example_usage.py [--run-async]
 
 Options:
-    --async    Run the example using the async client
+    --run-async    Run the example using the async client
 """
 
 import argparse


### PR DESCRIPTION
## Summary

The Python SDK test documentation described `MORPHIK_TEST_URL` as the way to point live SDK tests at a custom Morphik server, but the sync and async SDK tests read `MORPHIK_TEST_URI`. This updates the SDK test examples and environment-variable reference so contributors use the variable the tests actually consume.

## Changes

- Update the Python SDK README live-test example to use `MORPHIK_TEST_URI`.
- Update the SDK test README custom-server example to use `MORPHIK_TEST_URI`.
- Update the SDK test README environment-variable reference to name `MORPHIK_TEST_URI`.
- Clarify that the custom server URI applies to both sync and async SDK tests.
- Warn that the live SDK tests and example script mutate server state, may leave residual artifacts, and should only target local or disposable test environments.
- Direct contributors to source credential-bearing `morphik://` URIs from local secrets instead of inline commands or CI logs.
- Correct the example-usage async flag to `--run-async`, align the script usage docstring, and document the verified `uv run python` invocations.

## Why this matters

Contributors running the SDK tests against a non-default server need the documented environment variable to match the test code. The previous docs could silently fall back to `http://localhost:8000`, making local SDK verification confusing.

## Tests

Commands run:

- `rg -n "MORPHIK_TEST_(URL|URI)" sdks/python/README.md sdks/python/morphik/tests/README.md sdks/python/morphik/tests/test_sync.py sdks/python/morphik/tests/test_async.py` - passed; SDK docs and tests consistently reference `MORPHIK_TEST_URI`.
- `git diff --check origin/main...HEAD` - passed.
- `uv run python -m morphik.tests.example_usage --help` - passed; shows `--run-async`.
- `cd sdks/python/morphik/tests && PYTHONPATH=../.. uv run python example_usage.py --help` - passed; shows `--run-async`.
- `uv run python -m py_compile sdks/python/morphik/tests/example_usage.py` - passed.
- `uv run pytest --collect-only -q sdks/python/morphik/tests/test_sync.py sdks/python/morphik/tests/test_async.py` - passed; 26 tests collected.

Not run:

- Live SDK test execution against a running Morphik server; this is a documentation and usage-docstring change, and those tests require a server.

## Risk

Risk level: low

This is a documentation and usage-docstring correction matching existing test behavior. There is no runtime behavior change, and rollback is a direct revert of the README and usage-docstring edits.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

I intentionally did not add `MORPHIK_TEST_URL` as an alias in test code because the existing SDK tests already have a single variable contract; this PR only corrects the docs to match it.
