### PR TITLE
docs: stop advertising Docker artifacts as MIT licensed

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -173,4 +173,4 @@ For issues and feature requests:
 
 ## Repository Information
 
-- License: MIT
+- License: The Docker image bundles components under multiple licenses. Review [LICENSE](./LICENSE), [ee/LICENSE](./ee/LICENSE), and bundled package metadata before production use.

--- a/dockerfile
+++ b/dockerfile
@@ -191,7 +191,6 @@ LABEL org.opencontainers.image.title="Morphik Core"
 LABEL org.opencontainers.image.description="Morphik Core - A powerful document processing and retrieval system"
 LABEL org.opencontainers.image.source="https://github.com/morphik-org/morphik-core"
 LABEL org.opencontainers.image.version="1.0.0"
-LABEL org.opencontainers.image.licenses="MIT"
 
 # Expose port
 EXPOSE 8000


### PR DESCRIPTION
## Summary

`DOCKER.md` listed Morphik Core as MIT licensed, and the official Docker image label used the same stale MIT license metadata. The official Docker image bundles components with multiple license sources. This removes the top-level Docker guide and OCI-label MIT signals and points Docker readers to repository license files plus bundled package metadata instead of inventing an incomplete image license expression.

## Changes

- Replace the stale `License: MIT` line in `DOCKER.md`.
- State that the Docker image bundles components under multiple licenses, and tell operators to review repository license files plus bundled package metadata before production use.
- Remove the stale `org.opencontainers.image.licenses="MIT"` label from the official Dockerfile instead of replacing it with an incomplete single-license expression.

## Why this matters

Operators and contributors often check deployment docs and image metadata before running software. Stale top-level MIT statements in those surfaces can create avoidable confusion around use, distribution, and compliance scanning.

## Tests

Commands run:

- `rg -n -F -- "- License: The Docker image bundles components under multiple licenses. Review [LICENSE](./LICENSE), [ee/LICENSE](./ee/LICENSE), and bundled package metadata before production use." DOCKER.md` - passed.
- `if rg -n "License:\\s*MIT|org.opencontainers.image.licenses=\"MIT\"|org.opencontainers.image.licenses=\"BUSL-1.1\"" dockerfile DOCKER.md -S; then echo "unexpected top-level Docker license reference found"; exit 1; else echo "no stale top-level Docker doc/OCI label reference found"; fi` - passed.
- `docker buildx build --check -f dockerfile .` - passed; Dockerfile static check completed with no warnings.
- `git diff --check origin/main...HEAD` - passed.

Not run:

- Legal review; this is a Docker-facing consistency fix against the repository-provided license files.
- Full Docker image build; the Dockerfile static check passed, but the full dependency-heavy image was not built.

## Risk

Risk level: low

This is a documentation and Docker image metadata correction with no runtime behavior change. Removing the OCI license annotation means registry or compliance views may show no machine-readable image license until maintainers define a complete image-level licensing strategy, which is safer than publishing a known-incomplete single-license expression. Rollback is a direct revert of the `DOCKER.md` and `dockerfile` edits.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

I intentionally avoided adding legal interpretation beyond the repository's existing license files.

This intentionally leaves bundled package metadata, such as the `morphik_rust` crate's `license = "MIT"` declaration and `fde`'s package license metadata, out of scope even though those packages are copied into the image. Those package surfaces may be intentionally component-specific and should be reviewed separately by maintainers or legal counsel.

This updates repository source files for future image builds. It does not change metadata on historical image tags that were already published.

Follow-up opportunities intentionally left out of scope: define a complete image-level machine-readable licensing strategy, consider SBOM/provenance publication for container images, and review other OCI labels such as the static image version.
