### PR TITLE
docs: align UI component command guidance with scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ npm run dev              # Development server
 
 # Build and quality
 npm run build            # Production build
-npm run build:package    # Package build
+npm start                # Serve the production build
 npm run lint             # ESLint
 npm run format           # Prettier formatting
 npm run format:check     # Check formatting

--- a/ee/ui-component/README.md
+++ b/ee/ui-component/README.md
@@ -1,4 +1,4 @@
-# @morphik/ui
+# Morphik UI Component
 
 A modern React-based UI for Morphik, built with Next.js and Tailwind CSS. This component provides a user-friendly interface for:
 
@@ -7,61 +7,25 @@ A modern React-based UI for Morphik, built with Next.js and Tailwind CSS. This c
 - Real-time document processing feedback
 - Query testing and prototyping
 
-## Installation
+## Development Quick Start
+
+The UI component is a private Next.js app in this repository. It is not published as an `@morphik/ui` package.
+Run these commands from `ee/ui-component`:
 
 ```bash
-npm install @morphik/ui
+npm install
+npm run dev
 ```
 
-## Usage
+Open [http://localhost:3000](http://localhost:3000) and connect to a running local Morphik server with `localhost:8000`.
 
-```jsx
-import { MorphikUI } from "@morphik/ui";
-
-export default function YourApp() {
-  return (
-    <MorphikUI
-      connectionUri="your-connection-uri"
-      apiBaseUrl="http://your-api-base-url"
-      isReadOnlyUri={false}
-      onUriChange={uri => console.log("URI changed:", uri)}
-    />
-  );
-}
-```
-
-## Props
-
-| Prop            | Type                    | Default                   | Description                            |
-| --------------- | ----------------------- | ------------------------- | -------------------------------------- |
-| `connectionUri` | `string`                | `undefined`               | Connection URI for Morphik API         |
-| `apiBaseUrl`    | `string`                | `"http://localhost:8000"` | Base URL for API requests              |
-| `isReadOnlyUri` | `boolean`               | `false`                   | Controls whether the URI can be edited |
-| `onUriChange`   | `(uri: string) => void` | `undefined`               | Callback when URI is changed           |
+The routed app lives under `app/`; a reusable dashboard component also exists at `components/MorphikUI.tsx`. Check `components/types.ts` for the supported internal prop contract before embedding it elsewhere in this app.
 
 ## Prerequisites
 
 - Node.js 18 or later
 - npm or yarn package manager
 - A running Morphik server
-
-## Development Quick Start
-
-1. Install dependencies:
-
-```bash
-npm install
-```
-
-2. Start the development server:
-
-```bash
-npm run dev
-```
-
-3. Open [http://localhost:3000](http://localhost:3000) in your browser
-
-4. Connect to your Morphik server using a URI from the `/local/generate_uri` endpoint
 
 ## Features
 
@@ -82,7 +46,7 @@ npm run dev
 - **Connection Management**
   - Easy server connection
   - Connection status indicator
-  - Automatic reconnection
+  - Cloud connection persistence and automatic local connection clearing on restart
   - Error handling
 
 ## Development
@@ -110,6 +74,8 @@ ui-component/
 npm run build
 npm start
 ```
+
+There is no `build:package` script in this package.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` listed `npm run build:package` for the UI component, but `ee/ui-component/package.json` does not define that script. The UI README also described the checked-in package as an installable `@morphik/ui` package and included stale component-prop guidance even though the package is private and named `morphik-ui`. This updates the local UI guidance so it matches the actual frontend scripts and package metadata.

## Changes

- Replace the nonexistent `npm run build:package` command in `CLAUDE.md` with the supported `npm start` production-server command.
- Update the UI README to describe the checked-in private Next.js app workflow instead of an installable `@morphik/ui` package.
- Remove stale install/import example and incomplete prop-table guidance, including the nonexistent `onUriChange` prop.
- Clarify the default local connection path without documenting token-bearing URI generation in the UI quick start.

## Why this matters

Agent and UI development command references should be executable. Removing stale commands and package-install claims prevents wasted debugging time when someone follows the checked-in UI workflow.

## Tests

Commands run:

- `npm run` from `ee/ui-component` - passed; listed `dev`, `build`, `start`, `lint`, `format`, and `format:check`, with no `build:package` script.
- `rg -n "build:package|@morphik/ui|npm install @morphik/ui|onUriChange|isReadOnlyUri|Automatic reconnection|localhost:8000|npm run build|npm run lint|format:check|npm run format|npm start" CLAUDE.md ee/ui-component/package.json ee/ui-component/README.md docker-compose.run.yml -S` - passed; stale package-build, package-install, component-prop, and feature-bullet references were removed while current build/start commands and default local connection guidance remain documented.
- `git diff --check origin/main...HEAD` - passed.

Not run:

- `npm run build`; this PR only updates documentation and does not change frontend code or package scripts.
- `npm run lint`; same reason.

## Risk

Risk level: low

This is a documentation correction with no runtime behavior change. Rollback is a direct revert of the `CLAUDE.md` and `ee/ui-component/README.md` edits.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

I intentionally did not add a replacement `build:package` script because the supported checked-in workflow is the existing `npm run build` / `npm start` path, not a package-build script.
