### PR TITLE
docs: correct Docker installer local URI endpoint

### DIFF
--- a/install_docker.ps1
+++ b/install_docker.ps1
@@ -315,8 +315,9 @@ function Try-Extract-Config {
 
 function Update-AuthBypassOrPassword {
   Write-Host ""; Write-Info "Setting up authentication for your Morphik deployment:"
-  Write-Info " • For external access, set a LOCAL_URI_PASSWORD."
+  Write-Info " • Set a LOCAL_URI_PASSWORD when you want to protect local connection URI generation."
   Write-Info " • For local-only access, press Enter to enable bypass_auth_mode."
+  Write-Info " • With a LOCAL_URI_PASSWORD set, use POST /local/generate_uri with password_token in the form body to create an authorized local connection URI."
   $password = Read-Host "Enter a secure LOCAL_URI_PASSWORD (or press Enter to skip)"
   if ([string]::IsNullOrWhiteSpace($password)) {
     Write-Info "No password provided - enabling authentication bypass (bypass_auth_mode=true)."
@@ -324,7 +325,9 @@ function Update-AuthBypassOrPassword {
     $content = $content -replace '(?m)^bypass_auth_mode\s*=\s*false', 'bypass_auth_mode = true'
     Set-Content morphik.toml -Value $content
   } else {
-    Write-Ok "LOCAL_URI_PASSWORD set - keeping production mode (bypass_auth_mode=false)."
+    Write-Ok "LOCAL_URI_PASSWORD set - keeping authenticated mode (bypass_auth_mode=false)."
+    Write-Info "Use POST /local/generate_uri with password_token in the form body to create authorized local connection URIs."
+    Write-Info "Treat generated local connection URIs as bearer credentials."
     (Get-Content .env -Raw) -replace 'LOCAL_URI_PASSWORD=', "LOCAL_URI_PASSWORD=$password" |
       Set-Content .env
   }

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -330,9 +330,9 @@ fi
 # 5.0.5 Now that morphik.toml exists, handle LOCAL_URI_PASSWORD configuration
 echo ""
 print_info "🔐 Setting up authentication for your Morphik deployment:"
-print_info "   • If you plan to access Morphik from outside this server, setting a LOCAL_URI_PASSWORD will secure your deployment"
+print_info "   • Set LOCAL_URI_PASSWORD when you want to protect local connection URI generation"
 print_info "   • For local-only access, you can skip this step (bypass_auth_mode will be enabled)"
-print_info "   • With a LOCAL_URI_PASSWORD set, you'll need to use /generate_local_uri endpoint for authorization tokens"
+print_info "   • With a LOCAL_URI_PASSWORD set, use POST /local/generate_uri with password_token in the form body to create an authorized local connection URI"
 echo ""
 read -p "Please enter a secure LOCAL_URI_PASSWORD (or press Enter to skip for local-only access): " local_uri_password < /dev/tty
 if [[ -z "$local_uri_password" ]]; then
@@ -346,8 +346,9 @@ if [[ -z "$local_uri_password" ]]; then
         print_warning "morphik.toml not found, cannot set bypass_auth_mode"
     fi
 else
-    print_success "LOCAL_URI_PASSWORD set - keeping production mode (bypass_auth_mode=false) with authentication enabled"
-    print_info "Use the /generate_local_uri endpoint with this password to create authorized connection URIs"
+    print_success "LOCAL_URI_PASSWORD set - keeping authenticated mode (bypass_auth_mode=false)"
+    print_info "Use POST /local/generate_uri with password_token in the form body to create authorized local connection URIs"
+    print_info "Treat generated local connection URIs as bearer credentials"
 fi
 
 # Only update .env if a password was provided


### PR DESCRIPTION
## Summary

`install_docker.sh` tells users who configure `LOCAL_URI_PASSWORD` to use `/generate_local_uri`, but the local URI API route is `POST /local/generate_uri`. This updates the Docker installer guidance so users are pointed at the endpoint that actually exists, including the required `password_token` form field.

## Changes

- Replace stale bash installer references to `/generate_local_uri` with `POST /local/generate_uri`.
- Add matching PowerShell installer guidance for the same endpoint.
- Mention that the configured password is sent as `password_token` in the form body.
- Clarify that `LOCAL_URI_PASSWORD` protects local connection URI generation, not the entire deployment.
- Mention that generated local connection URIs are bearer credentials.
- Leave installer behavior, auth configuration, and API routes unchanged.

## Why this matters

The Docker installers are first-run paths for self-hosted deployments. If users set `LOCAL_URI_PASSWORD`, the current bash guidance sends them to a nonexistent endpoint when they need an authorized local connection URI. The updated wording also avoids overstating what the password protects and reminds operators that generated local URIs are credentials.

## Tests

Commands run:

- `bash -n install_docker.sh` - passed.
- `if command -v pwsh >/dev/null 2>&1; then pwsh -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw install_docker.ps1)); Write-Output "PowerShell parse passed"'; elif command -v powershell >/dev/null 2>&1; then powershell -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw install_docker.ps1)); Write-Output "PowerShell parse passed"'; else echo "PowerShell unavailable; parse check not run"; fi` - PowerShell was unavailable, so parse check was not run.
- `rg -n "generate_local_uri|/local/generate_uri|LOCAL_URI_PASSWORD|password_token|bearer credentials|protect local connection URI generation|authorized local connection URI" install_docker.sh install_docker.ps1 core/api.py core/auth_utils.py` - passed; installers now point at `POST /local/generate_uri`, and `core/api.py` exposes that route with the `password_token` form field.
- `if rg -n "For external access|outside this server|server_mode|public-IP detection|public IP|localhost fallback|fall back to localhost" install_docker.sh install_docker.ps1 -S; then echo "unexpected external/server-mode installer guidance remains"; exit 1; else echo "no external/server-mode installer guidance remains"; fi` - passed.
- `if rg -n "/generate_local_uri|generate_local_uri" install_docker.sh install_docker.ps1 -S; then echo "stale installer endpoint reference remains"; exit 1; else echo "no stale installer endpoint reference remains"; fi` - passed.
- `git diff --check origin/main...HEAD` - passed.

Not run:

- The interactive Docker installers were not run because this PR only changes printed guidance.
- A live request to `/local/generate_uri` was not run because it requires a running configured server and `LOCAL_URI_PASSWORD`.

## Risk

Risk level: low code risk; medium remaining DX limitation for external URI generation

This is a small installer guidance correction with no runtime behavior change. Rollback is a direct revert of the installer message updates. External-host URI generation remains intentionally out of scope because the current `server_mode=true` behavior depends on public-IP autodetection and fallback behavior that deserves a separate reliability/docs change.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

I intentionally did not add a `/generate_local_uri` API alias; the stale installer copy is the narrow problem fixed here. I also left `server_mode=true` guidance out of the installer copy because external-host URI generation depends on public-IP autodetection and fallback behavior that deserves a separate focused docs or reliability change.
