### PR TITLE
fix: avoid logging connection credentials in the UI

### DIFF
--- a/ee/ui-component/contexts/morphik-context.tsx
+++ b/ee/ui-component/contexts/morphik-context.tsx
@@ -38,7 +38,9 @@ function getStoredConnectionUri(): string | null {
     if (stored && stored.includes("://morphik://")) {
       // Remove the leading protocol from malformed URIs like https://morphik://...
       const cleaned = stored.replace(/^https?:\/\//, "");
-      console.log("Cleaning malformed stored URI:", stored, "→", cleaned);
+      console.log("Cleaning malformed stored connection URI", {
+        hadHttpProtocolPrefix: /^https?:\/\//.test(stored),
+      });
       window.localStorage.setItem(CONNECTION_URI_STORAGE_KEY, cleaned);
       return cleaned;
     }
@@ -49,7 +51,10 @@ function getStoredConnectionUri(): string | null {
       const match = stored.match(/^morphik:\/\/local@(.+)$/);
       if (match && match[1]) {
         const migratedUri = match[1];
-        console.log("Migrating old URI format:", stored, "→", migratedUri);
+        console.log("Migrating stored local connection URI format", {
+          from: "morphik-local",
+          to: "host",
+        });
         // Update storage with migrated value
         window.localStorage.setItem(CONNECTION_URI_STORAGE_KEY, migratedUri);
         return migratedUri;
@@ -106,7 +111,7 @@ export function MorphikProvider({
 
     // Clear stored URI if it's a local connection (on app restart)
     if (storedUri && isLocalUri(storedUri)) {
-      console.log("Clearing stored local connection URI on app restart:", storedUri);
+      console.log("Clearing stored local connection URI on app restart");
       setStoredConnectionUri(null);
       // Use initial value or external prop for local connections
       return externalConnectionUri || initialConnectionUri;
@@ -133,7 +138,11 @@ export function MorphikProvider({
 
     // Safety check: ensure it's a proper HTTP(S) URL
     if (!url.startsWith("http://") && !url.startsWith("https://")) {
-      console.error("[MorphikContext] Invalid apiBaseUrl:", url);
+      console.error("[MorphikContext] Invalid apiBaseUrl", {
+        hasValue: Boolean(connectionInfo.apiBaseUrl),
+        hasHttpProtocol: url.startsWith("http://"),
+        hasHttpsProtocol: url.startsWith("https://"),
+      });
       return DEFAULT_API_BASE_URL;
     }
 
@@ -161,7 +170,7 @@ export function MorphikProvider({
     } else if (connectionUri && connectionInfo && connectionInfo.type === "local") {
       // For local connections, we can optionally store temporarily
       // but it will be cleared on next app restart
-      console.log("Local connection - will be cleared on restart:", connectionUri);
+      console.log("Local connection will be cleared on restart");
       setStoredConnectionUri(connectionUri);
     } else {
       // Clear storage if no URI
@@ -171,21 +180,17 @@ export function MorphikProvider({
 
   const updateConnectionUri = (uri: string) => {
     if (!isReadOnlyUri) {
-      console.log("[MorphikContext] updateConnectionUri:", uri);
+      console.log("[MorphikContext] updateConnectionUri");
       setConnectionUri(uri);
     }
   };
 
   // Debug log when values change
   React.useEffect(() => {
-    console.log("[MorphikContext] Current values:", {
-      connectionUri,
-      connectionInfo,
-      apiBaseUrl,
-      authToken,
-      isLocal,
+    console.log("[MorphikContext] Connection state changed:", {
+      hasConnection: Boolean(connectionUri),
     });
-  }, [connectionUri, connectionInfo, apiBaseUrl, authToken, isLocal]);
+  }, [connectionUri]);
 
   return (
     <MorphikContext.Provider

--- a/ee/ui-component/lib/connection-utils.ts
+++ b/ee/ui-component/lib/connection-utils.ts
@@ -44,7 +44,9 @@ export function parseConnectionUri(uri: string): ConnectionInfo {
   if (uri.includes("://morphik://")) {
     // Remove the leading protocol if someone entered https://morphik://...
     cleanUri = uri.replace(/^https?:\/\//, "");
-    console.warn("Cleaning malformed URI:", uri, "→", cleanUri);
+    console.warn("Cleaning malformed connection URI", {
+      hadHttpProtocolPrefix: /^https?:\/\//.test(uri),
+    });
   }
 
   // Check if it's already a morphik:// URI
@@ -165,7 +167,7 @@ export function clearLocalConnectionFromStorage(): void {
   try {
     const stored = window.localStorage.getItem(CONNECTION_URI_STORAGE_KEY);
     if (stored && isLocalUri(stored)) {
-      console.log("Clearing local connection from storage:", stored);
+      console.log("Clearing local connection from storage");
       window.localStorage.removeItem(CONNECTION_URI_STORAGE_KEY);
     }
   } catch {

--- a/ee/ui-component/lib/utils.ts
+++ b/ee/ui-component/lib/utils.ts
@@ -18,7 +18,6 @@ export function extractTokenFromUri(uri: string | undefined): string | null {
   if (!uri) return null;
 
   try {
-    console.log("Attempting to extract token from URI:", uri);
     // The URI format is: morphik://appname:token@host
     // We need to extract just the token part (after the colon and before the @)
 
@@ -35,15 +34,13 @@ export function extractTokenFromUri(uri: string | undefined): string | null {
     if (authPart.includes(":")) {
       // Format is appname:token
       const fullToken = authPart.split(":")[1];
-      console.log("Extracted token:", fullToken ? `${fullToken.substring(0, 5)}...` : "null");
       return fullToken;
     } else {
       // Old format with just token (no appname:)
-      console.log("Extracted token (old format):", authPart ? `${authPart.substring(0, 5)}...` : "null");
       return authPart;
     }
-  } catch (err) {
-    console.error("Error extracting token from URI:", err);
+  } catch {
+    console.error("Error extracting token from URI");
     return null;
   }
 }
@@ -85,10 +82,9 @@ export function getApiBaseUrlFromUri(uri: string | undefined, defaultUrl: string
       }
     }
 
-    console.log("Extracted API base URL:", host);
     return host;
-  } catch (err) {
-    console.error("Error extracting host from URI:", err);
+  } catch {
+    console.error("Error extracting host from URI");
     return defaultUrl; // Default on error
   }
 }


### PR DESCRIPTION
## Summary

The UI had several debug logs that could print full Morphik connection URIs, parsed connection objects, extracted token prefixes, or connection-derived URLs. Because Morphik connection URIs can include bearer credentials, this PR keeps only event-level connection debug messages and removes credential-bearing values from the browser console.

## Changes

- Redact connection URI migration, storage cleanup, update, and invalid URL logs in `MorphikProvider`.
- Avoid logging parsed `connectionInfo`, `authToken`, raw connection URIs, token prefixes, adjacent URI parsing exception objects, and the connection-derived API base URL in the utility path touched by this PR.
- Keep only non-sensitive diagnostic signals: `hadHttpProtocolPrefix`, `hasConnection`, and invalid-URL protocol/value booleans.

## Why this matters

Debug logging should not expose bearer credentials or values derived from bearer connection URIs. This reduces accidental credential exposure during local debugging and issue reproduction without changing connection parsing, storage, authorization header creation, or API URL construction behavior.

## Tests

Commands run:

- `npm install --package-lock=false` from `ee/ui-component` — passed; installed local dependencies without creating a lockfile.
- `npx next lint --file contexts/morphik-context.tsx --file lib/connection-utils.ts --file lib/utils.ts` from `ee/ui-component` — passed.
- `npx prettier --check contexts/morphik-context.tsx lib/connection-utils.ts lib/utils.ts` from `ee/ui-component` — passed.
- `npx tsc --noEmit --pretty false` from `ee/ui-component` — passed.
- `if rg -n "console\\.(log|debug|info|warn|error)\\([^\\n]*,\\s*(connectionUri|authToken|connectionInfo|storedUri|stored|uri|token|fullToken|authPart|cleanUri|migratedUri|host|url|err)\\b|console\\.(log|debug|info|warn|error)\\([^\\n]*\\{[^\\n]*(connectionUri|authToken|connectionInfo|storedUri|stored|uri|token|fullToken|authPart|cleanUri|migratedUri|host|url|err)\\s*[,}]" ee/ui-component/contexts/morphik-context.tsx ee/ui-component/lib/connection-utils.ts ee/ui-component/lib/utils.ts -S; then echo "raw credential-related console argument remains"; exit 1; else echo "no raw credential-related console arguments found"; fi` — passed.
- `git diff --check origin/main...HEAD` — passed.

Also run:

- `npm run lint` from `ee/ui-component` — failed on pre-existing unrelated issues in `components/ui/button.tsx` and `components/ui/sheet.tsx`, plus existing warnings in chat/settings components.
- `npm run build` from `ee/ui-component` — compiled successfully, then failed at the same existing lint gate unrelated to the touched files.

## Risk

Risk level: low

This is a logging-only change. It does not alter the connection URI parser, localStorage persistence behavior, generated authorization headers, or API base URL selection. Rollback is straightforward by restoring the previous console output, though that would reintroduce credential exposure risk.

The tradeoff is that malformed-URI and parsing failure logs now include less debugging context than before. In particular, raw invalid URL values and caught exception objects are no longer logged. Routine diagnosis still gets event-level messages, but deep debugging may require local reproduction or temporary local instrumentation rather than relying on browser logs that can be shared.

## Issue

No existing issue.

## Notes for maintainers

README examples were intentionally left unchanged because this PR only affects console redaction, not connection URI behavior.

This PR also does not change connection URI persistence or transport/protocol defaults. Those are broader behavior changes that should be reviewed separately from this logging-only hardening.
