### PR TITLE
test: point pytest discovery at existing test roots

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,8 +8,10 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 
-# Test paths - ensure this points to your test directory relative to pytest.ini location
-testpaths = tests
+# Test paths - keep these aligned with the repository's actual test roots
+testpaths =
+    core/tests
+    sdks/python/morphik/tests
 
 # Markers
 markers =
@@ -31,10 +33,10 @@ log_cli_level = INFO
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format = %Y-%m-%d %H:%M:%S
 
-# Python path - ensure core and sdk are in path
+# Python path - repo root for core tests and local SDK package root for SDK tests
 pythonpath =
     .
-    ../sdks/python
+    sdks/python
 
 # Directories to ignore
 norecursedirs =


### PR DESCRIPTION
## Summary

Pytest was configured to look for tests under a root-level `tests/` directory that does not exist in this repository. That made local collection emit `PytestConfigWarning: No files were found in testpaths` and then fall back to recursive discovery.

This PR points pytest at the repository's real Python test roots and corrects the SDK `pythonpath` entry to the actual local SDK package path.

## Changes

- Update `pytest.ini` `testpaths` to `core/tests` and `sdks/python/morphik/tests`.
- Update `pytest.ini` `pythonpath` from non-existent `../sdks/python` to the local SDK package root at `sdks/python`.
- Refresh the inline testpaths comment so it reflects the repository layout.

## Why this matters

Contributors should not see a misleading pytest configuration warning when collecting tests from the repository root. Keeping pytest discovery and import paths aligned with the actual repo layout makes local test feedback clearer and avoids relying on recursive fallback behavior.

This also removes false configuration noise for maintainers validating branches from the repository root, and it makes root collection use the workspace SDK package instead of depending on whatever SDK package happens to be importable.

## Tests

Commands run:

- `.venv/bin/python -m pytest --collect-only -q --ignore=core/tests/unit/test_ingestion_colpali_rendering.py -W error::pytest.PytestConfigWarning` — passed; collected 242 tests and reported `testpaths: core/tests, sdks/python/morphik/tests`.
- `git diff --check origin/main...HEAD` — passed.

## Known pre-existing issue

I also ran `.venv/bin/python -m pytest --collect-only -q` to check the root collection behavior end to end. It still fails on the existing `ValueError: 'POSTGRES_URI' needed if 'database.provider' is set to 'postgres'` collection error from `core/tests/unit/test_ingestion_colpali_rendering.py`, which is outside this PR's scope. The previous missing-testpaths warning was gone in that run.

## Risk

Risk level: low

This is limited to pytest configuration. The intended behavior change is that root-level pytest collection uses the explicit repository test roots instead of a missing path plus recursive fallback.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

This PR intentionally does not address the existing `POSTGRES_URI` import-time collection failure. That is separate from pytest discovery configuration.

Follow-up worth considering: the root pytest configuration now explicitly includes both core and SDK tests, matching current recursive discovery behavior. A later PR could clarify marker/default-suite policy for SDK live-server tests if maintainers want a separate offline-only root command.
