### PR TITLE
fix: harden Docker auth signing secrets

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -4,7 +4,7 @@ Morphik Core provides a streamlined Docker-based setup that includes all necessa
 
 ## Prerequisites
 
-- Docker and Docker Compose installed on your system
+- Docker and Docker Compose 2.24.0 or newer installed on your system
 - At least 10GB of free disk space (for models and data)
 - 8GB+ RAM recommended
 
@@ -16,7 +16,19 @@ git clone https://github.com/morphik-org/morphik-core.git
 cd morphik-core
 ```
 
-2. First-time setup:
+2. Create a `.env` file for Docker secrets:
+```bash
+umask 077
+cat > .env <<EOF
+JWT_SECRET_KEY=$(openssl rand -hex 32)
+SESSION_SECRET_KEY=$(openssl rand -hex 32)
+LOCAL_URI_PASSWORD=
+EOF
+```
+
+If `openssl` is not available, set `JWT_SECRET_KEY` and `SESSION_SECRET_KEY` to separate non-placeholder random hex values with at least 32 characters. Leave `LOCAL_URI_PASSWORD` blank unless you need `/local/generate_uri`. Shell-exported values for these same variables are also supported for CI or scripted deployments.
+
+3. First-time setup:
 ```bash
 docker compose up --build
 ```
@@ -29,13 +41,13 @@ This command will:
 
 The initial setup may take 5-10 minutes depending on your internet speed, as it needs to download the AI models.
 
-3. For subsequent runs:
+4. For subsequent runs:
 ```bash
 docker compose up    # Start all services
 docker compose down  # Stop all services
 ```
 
-4. To completely reset (will delete all data and models):
+5. To completely reset (will delete all data and models):
 ```bash
 docker compose down -v
 ```
@@ -84,14 +96,20 @@ storage_path = "/app/storage"
 
 ### 3. Environment Variables
 
-Create a `.env` file to customize these settings:
+Create a `.env` file before starting Docker. Docker Compose loads this file for both the API and worker services:
 
 ```bash
-JWT_SECRET_KEY=your-secure-key-here  # Important: Change in production
+JWT_SECRET_KEY=<32+-character-random-hex-secret>      # Important: Change in production
+SESSION_SECRET_KEY=<32+-character-random-hex-secret>  # Important: Change in production
+LOCAL_URI_PASSWORD=<32+-character-random-hex-secret>  # Only needed for /local/generate_uri
 OPENAI_API_KEY=sk-...                # Only if using OpenAI
 HOST=0.0.0.0                         # Leave as is for Docker
 PORT=8000                            # Change if needed
 ```
+
+When `bypass_auth_mode = false`, `JWT_SECRET_KEY` and `SESSION_SECRET_KEY` must be non-empty, non-placeholder values with at least 32 characters. If `LOCAL_URI_PASSWORD` is unset or blank, `/local/generate_uri` is disabled; if you set it, use a non-placeholder value with at least 32 characters. When writing secrets to `.env`, use hex values such as `openssl rand -hex 32` so Docker Compose does not treat characters like `$`, quotes, or `#` as env-file syntax.
+
+Upgrade note: existing authenticated Docker deployments must verify that `JWT_SECRET_KEY` and `SESSION_SECRET_KEY` are both non-placeholder random values with at least 32 characters before pulling an image with this validation. Use the same values for both the `morphik` API service and the `worker` service through `.env` or shell-exported environment variables. If `LOCAL_URI_PASSWORD` is set, replace weak or placeholder values with a non-placeholder 32+ character value, or clear it to disable `/local/generate_uri`.
 
 ### 4. Custom Configuration
 
@@ -135,12 +153,17 @@ services:
    - Check PostgreSQL is healthy: `docker compose ps`
    - Verify database connection: `docker compose exec postgres psql -U morphik -d morphik`
 
-3. **Model Download Issues**
+3. **Auth Secret Issues**
+   - If startup fails with `JWT_SECRET_KEY` or `SESSION_SECRET_KEY` validation errors, set both values in `.env` to non-placeholder random strings with at least 32 characters and restart
+   - If startup fails with `LOCAL_URI_PASSWORD` validation errors, replace it with a non-placeholder value with at least 32 characters, or clear it to disable `/local/generate_uri`
+   - If `/local/generate_uri` returns HTTP `503` with `LOCAL_URI_PASSWORD is not configured; /local/generate_uri is disabled`, set `LOCAL_URI_PASSWORD` in `.env` to a non-placeholder value with at least 32 characters before using that endpoint
+
+4. **Model Download Issues**
    - Check Ollama logs: `docker compose logs ollama`
    - Ensure enough disk space for models
    - Try restarting Ollama: `docker compose restart ollama`
 
-4. **Performance Issues**
+5. **Performance Issues**
    - Monitor resources: `docker stats`
    - Ensure sufficient RAM (8GB+ recommended)
    - Check disk space: `df -h`
@@ -150,7 +173,8 @@ services:
 For production environments:
 
 1. **Security**:
-   - Change the default `JWT_SECRET_KEY`
+   - Use randomly generated `JWT_SECRET_KEY` and `SESSION_SECRET_KEY` values of at least 32 characters; do not rely on example or development defaults
+   - Set a randomly generated `LOCAL_URI_PASSWORD` of at least 32 characters before using `/local/generate_uri`
    - Use proper network security groups
    - Enable HTTPS (recommended: use a reverse proxy)
    - Regularly update containers and dependencies

--- a/core/api.py
+++ b/core/api.py
@@ -31,6 +31,7 @@ from core.dependencies import get_optional_redis_pool, get_redis_pool
 from core.limits_utils import check_and_increment_limits
 from core.logging_config import setup_logging
 from core.middleware.profiling import ProfilingMiddleware
+from core.local_uri import require_local_uri_password_configured
 from core.models.auth import AuthContext
 from core.models.chat import ChatMessage
 from core.models.completion import CompletionResponse
@@ -970,14 +971,13 @@ async def get_available_models_for_selection(auth: AuthContext = Depends(verify_
 async def generate_local_uri(
     name: str = Form("admin"),
     expiry_days: int = Form(5475),  # 15 years
-    password_token: str = Form(...),
+    password_token: Optional[str] = Form(None),
     server_mode: bool = Form(False),
 ) -> Dict[str, str]:
     """Generate a development URI for running Morphik locally."""
     try:
         # Authenticate with LOCAL_URI_PASSWORD
-        if not settings.LOCAL_URI_PASSWORD:
-            raise HTTPException(status_code=500, detail="LOCAL_URI_PASSWORD not configured")
+        require_local_uri_password_configured(settings.LOCAL_URI_PASSWORD)
 
         if password_token != settings.LOCAL_URI_PASSWORD:
             raise HTTPException(status_code=401, detail="Invalid authentication token")

--- a/core/config.py
+++ b/core/config.py
@@ -12,6 +12,8 @@ from utils.env_loader import load_local_env
 # injecting variables.
 load_local_env(override=True)
 
+AUTH_SECRET_MIN_LENGTH = 32
+
 
 class ParserXMLSettings(BaseModel):
     max_tokens: int = 350
@@ -185,6 +187,72 @@ def get_settings() -> Settings:
     em = "'{missing_value}' needed if '{field}' is set to '{value}'"
     settings_dict = {}
 
+    def normalize_auth_secret(value: str) -> str:
+        normalized = value.strip()
+        if len(normalized) >= 2 and (
+            (normalized[0] == '"' and normalized[-1] == '"')
+            or (normalized[0] == "'" and normalized[-1] == "'")
+        ):
+            normalized = normalized[1:-1].strip()
+        return normalized
+
+    def env_or_default(name: str, default: str) -> str:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        normalized = normalize_auth_secret(value)
+        return normalized or default
+
+    def validate_auth_secrets(secret_values: Dict[str, str], *, context: str) -> None:
+        insecure_values = {
+            "JWT_SECRET_KEY": {
+                "dev-secret-key",
+                "<replace-with-strong-random-secret>",
+                "your-secret-key-here",
+                "your-secure-jwt-key-here",
+                "your-super-secret-key-change-in-production",
+            },
+            "SESSION_SECRET_KEY": {
+                "<replace-with-another-strong-secret>",
+                "super-secret-dev-session-key",
+                "your-secure-session-key-here",
+                "your-session-secret-key-change-in-production",
+            },
+            "LOCAL_URI_PASSWORD": {
+                "<replace-with-local-uri-password>",
+                "change-me-local-uri-password",
+                "local-uri-password",
+                "your-local-uri-password-here",
+            },
+        }
+        missing = [name for name, value in secret_values.items() if not value]
+        if missing:
+            secret_names = ", ".join(missing)
+            verb = "is" if len(missing) == 1 else "are"
+            raise ValueError(f"{secret_names} {verb} required {context}")
+
+        placeholders = [
+            name
+            for name, value in secret_values.items()
+            if value in insecure_values[name] or (value.startswith("<") and value.endswith(">"))
+        ]
+        if placeholders:
+            secret_names = ", ".join(placeholders)
+            verb = "uses" if len(placeholders) == 1 else "use"
+            raise ValueError(
+                f"{secret_names} {verb} an example or development default value; "
+                f"set non-placeholder values {context}"
+            )
+
+        short = [name for name, value in secret_values.items() if len(value) < AUTH_SECRET_MIN_LENGTH]
+        if short:
+            secret_names = ", ".join(short)
+            verb = "is" if len(short) == 1 else "are"
+            raise ValueError(
+                f"{secret_names} {verb} too short; set values with at least "
+                f"{AUTH_SECRET_MIN_LENGTH} characters {context}"
+            )
+
     # Load API config
     settings_dict.update(
         {
@@ -207,19 +275,32 @@ def get_settings() -> Settings:
         )
 
     # Load auth config
+    local_uri_password = normalize_auth_secret(os.environ.get("LOCAL_URI_PASSWORD", ""))
     settings_dict.update(
         {
             "JWT_ALGORITHM": config["auth"]["jwt_algorithm"],
-            "JWT_SECRET_KEY": os.environ.get("JWT_SECRET_KEY", "dev-secret-key"),  # Default for bypass mode
-            "SESSION_SECRET_KEY": os.environ.get("SESSION_SECRET_KEY", "super-secret-dev-session-key"),
+            "JWT_SECRET_KEY": env_or_default("JWT_SECRET_KEY", "dev-secret-key"),  # Default for bypass mode
+            "SESSION_SECRET_KEY": env_or_default("SESSION_SECRET_KEY", "super-secret-dev-session-key"),
+            "LOCAL_URI_PASSWORD": local_uri_password or None,
             "bypass_auth_mode": config["auth"].get("bypass_auth_mode", config["auth"].get("dev_mode", False)),
             "dev_user_id": config["auth"].get("dev_user_id", config["auth"].get("dev_entity_id", "dev_user")),
         }
     )
 
-    # Only require JWT_SECRET_KEY in non-dev mode
-    if not settings_dict["bypass_auth_mode"] and "JWT_SECRET_KEY" not in os.environ:
-        raise ValueError("JWT_SECRET_KEY is required when bypass_auth_mode is disabled")
+    # Authenticated mode must not start with missing, example, or weak signing secrets.
+    if not settings_dict["bypass_auth_mode"]:
+        signing_secret_values = {
+            "JWT_SECRET_KEY": normalize_auth_secret(os.environ.get("JWT_SECRET_KEY", "")),
+            "SESSION_SECRET_KEY": normalize_auth_secret(os.environ.get("SESSION_SECRET_KEY", "")),
+        }
+        validate_auth_secrets(signing_secret_values, context="when bypass_auth_mode is disabled")
+        settings_dict.update(signing_secret_values)
+
+    if settings_dict["LOCAL_URI_PASSWORD"]:
+        validate_auth_secrets(
+            {"LOCAL_URI_PASSWORD": settings_dict["LOCAL_URI_PASSWORD"]},
+            context="before using /local/generate_uri",
+        )
 
     # Load registered models if available
     if "registered_models" in config:
@@ -437,9 +518,6 @@ def get_settings() -> Settings:
         )
 
     settings_dict["TELEMETRY_ENABLED"] = os.getenv("TELEMETRY", "").strip().lower() != "false"
-
-    # Load LOCAL_URI_PASSWORD from environment
-    settings_dict["LOCAL_URI_PASSWORD"] = os.environ.get("LOCAL_URI_PASSWORD")
 
     # Load LiteLLM config (dummy API key for providers that don't need auth)
     settings_dict["LITELLM_DUMMY_API_KEY"] = os.environ.get("LITELLM_DUMMY_API_KEY", "ollama")

--- a/core/local_uri.py
+++ b/core/local_uri.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from fastapi import HTTPException
+
+
+LOCAL_URI_PASSWORD_DISABLED_DETAIL = "LOCAL_URI_PASSWORD is not configured; /local/generate_uri is disabled"
+
+
+def require_local_uri_password_configured(local_uri_password: Optional[str]) -> None:
+    if not local_uri_password:
+        raise HTTPException(status_code=503, detail=LOCAL_URI_PASSWORD_DISABLED_DETAIL)

--- a/core/tests/unit/test_config_auth_secrets.py
+++ b/core/tests/unit/test_config_auth_secrets.py
@@ -1,0 +1,290 @@
+"""Unit tests for authentication secret settings."""
+
+from pathlib import Path
+import re
+
+import pytest
+
+from core.config import get_settings
+
+
+ROOT_CONFIG = Path(__file__).resolve().parents[3] / "morphik.toml"
+STRONG_JWT_SECRET = "jwt-secret-0123456789abcdef0123456789"
+STRONG_SESSION_SECRET = "session-secret-0123456789abcdef0123456789"
+STRONG_LOCAL_URI_PASSWORD = "local-uri-password-0123456789abcdef0123456789"
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache(monkeypatch):
+    get_settings.cache_clear()
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("LOCAL_URI_PASSWORD", raising=False)
+    yield
+    get_settings.cache_clear()
+
+
+def _write_config(tmp_path, *, bypass_auth_mode):
+    text = ROOT_CONFIG.read_text()
+    replacement = f"bypass_auth_mode = {'true' if bypass_auth_mode else 'false'}"
+    text, replacements = re.subn(r"bypass_auth_mode = (true|false)", replacement, text, count=1)
+    assert replacements == 1
+    (tmp_path / "morphik.toml").write_text(text)
+
+
+def test_requires_session_secret_when_auth_bypass_is_disabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", STRONG_JWT_SECRET)
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="SESSION_SECRET_KEY is required when bypass_auth_mode is disabled"):
+        get_settings()
+
+
+def test_requires_both_signing_secrets_when_auth_bypass_is_disabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+
+    with pytest.raises(
+        ValueError,
+        match="JWT_SECRET_KEY, SESSION_SECRET_KEY are required when bypass_auth_mode is disabled",
+    ):
+        get_settings()
+
+
+@pytest.mark.parametrize("secret_value", ["", "   ", '""', '"   "', "''", "'   '"])
+def test_rejects_blank_session_secret_when_auth_bypass_is_disabled(tmp_path, monkeypatch, secret_value):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", STRONG_JWT_SECRET)
+    monkeypatch.setenv("SESSION_SECRET_KEY", secret_value)
+
+    with pytest.raises(ValueError, match="SESSION_SECRET_KEY is required when bypass_auth_mode is disabled"):
+        get_settings()
+
+
+@pytest.mark.parametrize("secret_value", ["", "   ", '""', '"   "', "''", "'   '"])
+def test_rejects_blank_jwt_secret_when_auth_bypass_is_disabled(tmp_path, monkeypatch, secret_value):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", secret_value)
+    monkeypatch.setenv("SESSION_SECRET_KEY", STRONG_SESSION_SECRET)
+
+    with pytest.raises(ValueError, match="JWT_SECRET_KEY is required when bypass_auth_mode is disabled"):
+        get_settings()
+
+
+@pytest.mark.parametrize(
+    ("jwt_secret", "session_secret", "error_match"),
+    [
+        (
+            "your-super-secret-key-change-in-production",
+            STRONG_SESSION_SECRET,
+            "JWT_SECRET_KEY uses an example or development default value",
+        ),
+        (
+            "dev-secret-key",
+            STRONG_SESSION_SECRET,
+            "JWT_SECRET_KEY uses an example or development default value",
+        ),
+        (
+            STRONG_JWT_SECRET,
+            "your-session-secret-key-change-in-production",
+            "SESSION_SECRET_KEY uses an example or development default value",
+        ),
+        (
+            STRONG_JWT_SECRET,
+            "super-secret-dev-session-key",
+            "SESSION_SECRET_KEY uses an example or development default value",
+        ),
+        (
+            "your-secure-jwt-key-here",
+            "your-secure-session-key-here",
+            "JWT_SECRET_KEY, SESSION_SECRET_KEY use an example or development default value",
+        ),
+        (
+            '"dev-secret-key"',
+            STRONG_SESSION_SECRET,
+            "JWT_SECRET_KEY uses an example or development default value",
+        ),
+        (
+            STRONG_JWT_SECRET,
+            "'your-secure-session-key-here'",
+            "SESSION_SECRET_KEY uses an example or development default value",
+        ),
+    ],
+)
+def test_rejects_example_auth_secrets_when_auth_bypass_is_disabled(
+    tmp_path, monkeypatch, jwt_secret, session_secret, error_match
+):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", jwt_secret)
+    monkeypatch.setenv("SESSION_SECRET_KEY", session_secret)
+
+    with pytest.raises(ValueError, match=error_match):
+        get_settings()
+
+
+@pytest.mark.parametrize(
+    ("jwt_secret", "session_secret", "error_match"),
+    [
+        ("short-jwt-secret", STRONG_SESSION_SECRET, "JWT_SECRET_KEY is too short"),
+        (STRONG_JWT_SECRET, "short-session-secret", "SESSION_SECRET_KEY is too short"),
+        ("short-jwt-secret", "short-session-secret", "JWT_SECRET_KEY, SESSION_SECRET_KEY are too short"),
+    ],
+)
+def test_rejects_short_auth_secrets_when_auth_bypass_is_disabled(
+    tmp_path, monkeypatch, jwt_secret, session_secret, error_match
+):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", jwt_secret)
+    monkeypatch.setenv("SESSION_SECRET_KEY", session_secret)
+
+    with pytest.raises(ValueError, match=error_match):
+        get_settings()
+
+
+def test_allows_missing_local_uri_password_when_auth_bypass_is_disabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", STRONG_JWT_SECRET)
+    monkeypatch.setenv("SESSION_SECRET_KEY", STRONG_SESSION_SECRET)
+    monkeypatch.delenv("LOCAL_URI_PASSWORD", raising=False)
+
+    settings = get_settings()
+
+    assert settings.LOCAL_URI_PASSWORD is None
+    assert settings.bypass_auth_mode is False
+
+
+@pytest.mark.parametrize("local_uri_password", ["", "   ", '""', '"   "', "''", "'   '"])
+def test_treats_blank_local_uri_password_as_disabled(tmp_path, monkeypatch, local_uri_password):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", STRONG_JWT_SECRET)
+    monkeypatch.setenv("SESSION_SECRET_KEY", STRONG_SESSION_SECRET)
+    monkeypatch.setenv("LOCAL_URI_PASSWORD", local_uri_password)
+
+    settings = get_settings()
+
+    assert settings.LOCAL_URI_PASSWORD is None
+    assert settings.bypass_auth_mode is False
+
+
+def test_loads_strong_local_uri_password_when_configured(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", STRONG_JWT_SECRET)
+    monkeypatch.setenv("SESSION_SECRET_KEY", STRONG_SESSION_SECRET)
+    monkeypatch.setenv("LOCAL_URI_PASSWORD", f'"{STRONG_LOCAL_URI_PASSWORD}"')
+
+    settings = get_settings()
+
+    assert settings.LOCAL_URI_PASSWORD == STRONG_LOCAL_URI_PASSWORD
+
+
+@pytest.mark.parametrize(
+    ("local_uri_password", "error_match"),
+    [
+        ("change-me-local-uri-password", "LOCAL_URI_PASSWORD uses an example or development default value"),
+        ("your-local-uri-password-here", "LOCAL_URI_PASSWORD uses an example or development default value"),
+        ("<replace-with-local-uri-password>", "LOCAL_URI_PASSWORD uses an example or development default value"),
+        ("short-local-uri-password", "LOCAL_URI_PASSWORD is too short"),
+    ],
+)
+def test_rejects_weak_local_uri_password_when_configured(
+    tmp_path, monkeypatch, local_uri_password, error_match
+):
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", STRONG_JWT_SECRET)
+    monkeypatch.setenv("SESSION_SECRET_KEY", STRONG_SESSION_SECRET)
+    monkeypatch.setenv("LOCAL_URI_PASSWORD", local_uri_password)
+
+    with pytest.raises(ValueError, match=error_match):
+        get_settings()
+
+
+def test_rejects_weak_local_uri_password_when_auth_bypass_is_enabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("LOCAL_URI_PASSWORD", "short-local-uri-password")
+
+    with pytest.raises(ValueError, match="LOCAL_URI_PASSWORD is too short"):
+        get_settings()
+
+
+def test_accepts_auth_secrets_at_minimum_length_when_auth_bypass_is_disabled(tmp_path, monkeypatch):
+    jwt_secret = "j" * 32
+    session_secret = "s" * 32
+    _write_config(tmp_path, bypass_auth_mode=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", jwt_secret)
+    monkeypatch.setenv("SESSION_SECRET_KEY", session_secret)
+    monkeypatch.setenv("LOCAL_URI_PASSWORD", "")
+
+    settings = get_settings()
+
+    assert settings.JWT_SECRET_KEY == jwt_secret
+    assert settings.SESSION_SECRET_KEY == session_secret
+    assert settings.LOCAL_URI_PASSWORD is None
+    assert settings.bypass_auth_mode is False
+
+
+def test_allows_default_auth_secrets_when_auth_bypass_is_enabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+
+    settings = get_settings()
+
+    assert settings.JWT_SECRET_KEY == "dev-secret-key"
+    assert settings.SESSION_SECRET_KEY == "super-secret-dev-session-key"
+    assert settings.bypass_auth_mode is True
+
+
+def test_uses_default_auth_secrets_for_blank_values_when_auth_bypass_is_enabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", "")
+    monkeypatch.setenv("SESSION_SECRET_KEY", "   ")
+
+    settings = get_settings()
+
+    assert settings.JWT_SECRET_KEY == "dev-secret-key"
+    assert settings.SESSION_SECRET_KEY == "super-secret-dev-session-key"
+    assert settings.bypass_auth_mode is True
+
+
+def test_uses_default_auth_secrets_for_quoted_blank_values_when_auth_bypass_is_enabled(tmp_path, monkeypatch):
+    _write_config(tmp_path, bypass_auth_mode=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+    monkeypatch.setenv("JWT_SECRET_KEY", '""')
+    monkeypatch.setenv("SESSION_SECRET_KEY", "'   '")
+
+    settings = get_settings()
+
+    assert settings.JWT_SECRET_KEY == "dev-secret-key"
+    assert settings.SESSION_SECRET_KEY == "super-secret-dev-session-key"
+    assert settings.bypass_auth_mode is True

--- a/core/tests/unit/test_installer_auth_env.py
+++ b/core/tests/unit/test_installer_auth_env.py
@@ -1,0 +1,308 @@
+"""Regression tests for Docker installer auth-secret environment wiring."""
+
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+
+import pytest
+from fastapi import HTTPException
+
+from core.local_uri import LOCAL_URI_PASSWORD_DISABLED_DETAIL, require_local_uri_password_configured
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _bash_function(source: str, name: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{.*?^\}}", source)
+    assert match is not None
+    return match.group(0)
+
+
+def _powershell_executable() -> str:
+    executable = shutil.which("pwsh") or shutil.which("powershell")
+    if executable is None:
+        pytest.skip("PowerShell runtime is required for PowerShell installer parser tests")
+    assert executable is not None
+    return executable
+
+
+def test_hosted_docker_installers_generate_session_secret():
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    powershell_installer = (ROOT / "install_docker.ps1").read_text()
+
+    assert 'generate_auth_secret "morphik-jwt"' in bash_installer
+    assert 'generate_auth_secret "morphik-session"' in bash_installer
+    assert "openssl rand -hex 32" in bash_installer
+    assert "Could not generate a secure auth secret" in bash_installer
+    assert "$jwt = \"morphik-jwt-$(New-RandomHex 32)\"" in powershell_installer
+    assert "$session = \"morphik-session-$(New-RandomHex 32)\"" in powershell_installer
+    assert "\"SESSION_SECRET_KEY=$session\"" in powershell_installer
+
+
+def test_compose_files_do_not_fallback_to_placeholder_auth_secrets():
+    def service_block(compose_text: str, service: str) -> str:
+        match = re.search(rf"(?ms)^  {service}:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)", compose_text)
+        assert match is not None
+        return match.group("body")
+
+    for compose_file in ("docker-compose.yml", "docker-compose.run.yml"):
+        compose_text = (ROOT / compose_file).read_text()
+        assert "JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}" not in compose_text
+        assert "JWT_SECRET_KEY=${JWT_SECRET_KEY:-}" in compose_text
+        assert "SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-}" in compose_text
+        assert "LOCAL_URI_PASSWORD=${LOCAL_URI_PASSWORD:-}" in compose_text
+
+        morphik_block = service_block(compose_text, "morphik")
+        worker_block = service_block(compose_text, "worker")
+
+        for block in (morphik_block, worker_block):
+            assert "env_file:" in block
+            assert "      - path: .env" in block
+            assert "        required: false" in block
+            assert "        format: raw" not in block
+            assert "      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-}" in block
+            assert "      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-}" in block
+            assert "      - LOCAL_URI_PASSWORD=${LOCAL_URI_PASSWORD:-}" in block
+
+
+def test_installers_require_compose_version_that_supports_optional_env_file():
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    powershell_installer = (ROOT / "install_docker.ps1").read_text()
+    docker_docs = (ROOT / "DOCKER.md").read_text()
+
+    assert 'MIN_COMPOSE_VERSION="2.24.0"' in bash_installer
+    assert "compose_version_at_least" in bash_installer
+    assert "optional env_file support" in bash_installer
+    assert "$script:MinComposeVersion = [Version]'2.24.0'" in powershell_installer
+    assert "optional env_file support" in powershell_installer
+    assert "Docker and Docker Compose 2.24.0 or newer" in docker_docs
+
+
+def test_bash_installer_compose_version_check_handles_boundaries():
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    function_def = _bash_function(bash_installer, "compose_version_at_least")
+    command = f"""
+    set -e
+    {function_def}
+    compose_version_at_least 2.24.0 2.24.0
+    compose_version_at_least v2.24.1 2.24.0
+    compose_version_at_least 3.0.0 2.24.0
+    ! compose_version_at_least 2.23.9 2.24.0
+    ! compose_version_at_least invalid 2.24.0
+    """
+
+    subprocess.run(["bash", "-c", command], check=True, text=True)
+
+
+def test_bash_installer_stops_before_writing_env_when_secret_generation_fails(tmp_path):
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    function_defs = "\n\n".join(
+        _bash_function(bash_installer, name)
+        for name in ("print_error", "protect_env_file", "generate_auth_secret")
+    )
+    command = f"""
+    set -e
+    PATH=/no-such-command
+    {function_defs}
+    jwt_secret="$(generate_auth_secret "morphik-jwt")"
+    cat > .env <<EOF
+JWT_SECRET_KEY=${{jwt_secret}}
+EOF
+    """
+
+    result = subprocess.run(["bash", "-c", command], cwd=tmp_path, capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "Could not generate a secure auth secret" in result.stderr
+    assert not (tmp_path / ".env").exists()
+
+
+@pytest.mark.parametrize("compose_file", ["docker-compose.yml", "docker-compose.run.yml"])
+def test_compose_files_load_auth_secrets_from_env_file(tmp_path, compose_file):
+    if shutil.which("docker") is None:
+        pytest.skip("Docker Compose is required for env-file rendering test")
+
+    source = (ROOT / compose_file).read_text()
+    source = re.sub(r"(?m)^\\s*- \\./[^\\n]+\\n", "", source)
+    (tmp_path / compose_file).write_text(source)
+    (tmp_path / "morphik.toml").write_text("")
+    env_values = {
+        "JWT_SECRET_KEY": "jwt-secret-0123456789abcdef0123456789",
+        "SESSION_SECRET_KEY": "session-secret-0123456789abcdef0123456789",
+        "LOCAL_URI_PASSWORD": "local-uri-password-0123456789abcdef0123456789",
+    }
+    (tmp_path / ".env").write_text("\n".join(f"{key}={value}" for key, value in env_values.items()) + "\n")
+    result = subprocess.run(
+        ["docker", "compose", "-f", compose_file, "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    for key, value in env_values.items():
+        assert f"{key}: {value}" in result.stdout
+
+
+@pytest.mark.parametrize("compose_file", ["docker-compose.yml", "docker-compose.run.yml"])
+def test_compose_files_allow_shell_secret_injection_without_env_file(tmp_path, monkeypatch, compose_file):
+    if shutil.which("docker") is None:
+        pytest.skip("Docker Compose is required for shell env rendering test")
+
+    source = (ROOT / compose_file).read_text()
+    source = re.sub(r"(?m)^\\s*- \\./[^\\n]+\\n", "", source)
+    (tmp_path / compose_file).write_text(source)
+    (tmp_path / "morphik.toml").write_text("")
+
+    env = {
+        "JWT_SECRET_KEY": "jwt-secret-0123456789abcdef0123456789",
+        "SESSION_SECRET_KEY": "session-secret-0123456789abcdef0123456789",
+        "LOCAL_URI_PASSWORD": "local-uri-password-0123456789abcdef0123456789",
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    result = subprocess.run(
+        ["docker", "compose", "-f", compose_file, "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    for key, value in env.items():
+        assert f"{key}: {value}" in result.stdout
+
+
+def test_installers_validate_local_uri_password_before_writing_env():
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    powershell_installer = (ROOT / "install_docker.ps1").read_text()
+
+    assert 'validate_local_uri_password "$local_uri_password"' in bash_installer
+    assert 'local_uri_password="$(normalize_auth_secret "$local_uri_password")"' in bash_installer
+    assert "LOCAL_URI_PASSWORD must be at least ${AUTH_SECRET_MIN_LENGTH} characters" in bash_installer
+    assert "LOCAL_URI_PASSWORD must not use an example or placeholder value" in bash_installer
+    assert "/local/generate_uri endpoint" in bash_installer
+    assert "/generate_local_uri endpoint" not in bash_installer
+    assert "read -r -s -p" in bash_installer
+    assert bash_installer.index('validate_local_uri_password "$local_uri_password"') < bash_installer.index(
+        'set_env_value "LOCAL_URI_PASSWORD" "$local_uri_password"'
+    )
+
+    assert "$password = Assert-LocalUriPassword -Value $password" in powershell_installer
+    assert "Read-Host -AsSecureString" in powershell_installer
+    assert "function ConvertFrom-SecureInput" in powershell_installer
+    assert "$normalized = Normalize-AuthSecret -Value $Value" in powershell_installer
+    assert "LOCAL_URI_PASSWORD must be at least $script:AuthSecretMinLength characters" in powershell_installer
+    assert "LOCAL_URI_PASSWORD must not use an example or placeholder value" in powershell_installer
+    assert powershell_installer.index("$password = Assert-LocalUriPassword -Value $password") < powershell_installer.index(
+        'Set-EnvValue -Key "LOCAL_URI_PASSWORD" -Value $password'
+    )
+    assert powershell_installer.index("$password = Normalize-AuthSecret -Value $password") < powershell_installer.index(
+        "if ([string]::IsNullOrWhiteSpace($password))"
+    )
+
+
+def test_installers_restrict_env_file_permissions():
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    powershell_installer = (ROOT / "install_docker.ps1").read_text()
+
+    assert "umask 077" in bash_installer
+    assert "chmod 600 .env" in bash_installer
+    assert "protect_env_file" in bash_installer
+    assert bash_installer.index("umask 077") < bash_installer.index("cat > .env <<EOF")
+    env_create_index = bash_installer.index("cat > .env <<EOF")
+    assert env_create_index < bash_installer.index("protect_env_file", env_create_index)
+
+    assert "function Protect-EnvFile" in powershell_installer
+    assert "$acl.SetAccessRuleProtection($true, $false)" in powershell_installer
+    assert "RemoveAccessRuleSpecific" in powershell_installer
+    assert "System.Security.AccessControl.FileSystemAccessRule" in powershell_installer
+    assert "Protect-EnvFile" in powershell_installer
+
+
+@pytest.mark.parametrize(
+    "local_uri_password",
+    [
+        "short-local-uri-password",
+        "your-local-uri-password-here",
+        "<replace-with-local-uri-password>",
+        '"123456789012345678901234567890"',
+    ],
+)
+def test_bash_installer_stops_before_writing_invalid_local_uri_password(tmp_path, local_uri_password):
+    bash_installer = (ROOT / "install_docker.sh").read_text()
+    function_defs = "\n\n".join(
+        _bash_function(bash_installer, name)
+        for name in ("print_error", "protect_env_file", "set_env_value", "normalize_auth_secret", "validate_local_uri_password")
+    )
+    command = f"""
+    set -e
+    AUTH_SECRET_MIN_LENGTH=32
+    {function_defs}
+    local_uri_password="$(normalize_auth_secret {shlex.quote(local_uri_password)})"
+    validate_local_uri_password "$local_uri_password" || exit 1
+    set_env_value "LOCAL_URI_PASSWORD" "$local_uri_password"
+    """
+
+    result = subprocess.run(["bash", "-c", command], cwd=tmp_path, capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "LOCAL_URI_PASSWORD" in result.stderr
+    assert not (tmp_path / ".env").exists()
+
+
+def test_local_uri_endpoint_has_explicit_disabled_response():
+    api_source = (ROOT / "core/api.py").read_text()
+
+    assert "password_token: Optional[str] = Form(None)" in api_source
+    assert "require_local_uri_password_configured(settings.LOCAL_URI_PASSWORD)" in api_source
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_local_uri_password_configured(None)
+
+    exception = exc_info.value
+    assert isinstance(exception, HTTPException)
+    assert exception.status_code == 503
+    assert exception.detail == LOCAL_URI_PASSWORD_DISABLED_DETAIL
+
+
+def test_docker_docs_describe_session_secret_requirement():
+    docker_docs = (ROOT / "DOCKER.md").read_text()
+
+    assert "Create a `.env` file for Docker secrets" in docker_docs
+    assert "docker compose up --build" in docker_docs
+    assert docker_docs.index("Create a `.env` file for Docker secrets") < docker_docs.index("docker compose up --build")
+    assert "umask 077" in docker_docs
+    assert "umask 077" in docker_docs[: docker_docs.index("cat > .env <<EOF")]
+    assert "JWT_SECRET_KEY=$(openssl rand -hex 32)" in docker_docs
+    assert "SESSION_SECRET_KEY=$(openssl rand -hex 32)" in docker_docs
+    assert "SESSION_SECRET_KEY=<32+-character-random-hex-secret>" in docker_docs
+    assert "JWT_SECRET_KEY` and `SESSION_SECRET_KEY` must be non-empty" in docker_docs
+    assert "`LOCAL_URI_PASSWORD` is unset or blank, `/local/generate_uri` is disabled" in docker_docs
+    assert "authenticated Docker deployments must verify that `JWT_SECRET_KEY` and `SESSION_SECRET_KEY`" in docker_docs
+    assert "through `.env` or shell-exported environment variables" in docker_docs
+    assert "use hex values such as `openssl rand -hex 32`" in docker_docs
+    assert "If startup fails with `LOCAL_URI_PASSWORD` validation errors" in docker_docs
+    assert "returns HTTP `503` with `LOCAL_URI_PASSWORD is not configured; /local/generate_uri is disabled`" in docker_docs
+    assert "If startup fails with `JWT_SECRET_KEY` or `SESSION_SECRET_KEY` validation errors" in docker_docs
+
+
+@pytest.mark.parametrize("script_name", ["install_docker.ps1"])
+def test_powershell_installer_parses_when_runtime_available(script_name):
+    powershell = _powershell_executable()
+    script_path = str(ROOT / script_name).replace("'", "''")
+    command = f"""
+    $tokens = $null
+    $errors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile('{script_path}', [ref] $tokens, [ref] $errors) | Out-Null
+    if ($errors.Count -gt 0) {{
+      $errors | ForEach-Object {{ Write-Error $_.Message }}
+      exit 1
+    }}
+    """
+
+    subprocess.run([powershell, "-NoProfile", "-NonInteractive", "-Command", command], check=True, text=True)

--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -11,7 +11,9 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-}
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-}
+      - LOCAL_URI_PASSWORD=${LOCAL_URI_PASSWORD:-}
       - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
       - PGPASSWORD=morphik # Used by internal health checks in the container
       - REDIS_HOST=redis
@@ -34,7 +36,8 @@ services:
     networks:
       - morphik-network
     env_file:
-      - .env
+      - path: .env
+        required: false
 
   worker:
     image: ghcr.io/morphik-org/morphik-core:${MORPHIK_VERSION:-latest}
@@ -42,7 +45,9 @@ services:
     # The worker runs as a background job processor, so no ports are exposed.
     command: arq core.workers.ingestion_worker.WorkerSettings
     environment:
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-}
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-}
+      - LOCAL_URI_PASSWORD=${LOCAL_URI_PASSWORD:-}
       - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
       - PGPASSWORD=morphik
       - REDIS_HOST=redis
@@ -62,7 +67,8 @@ services:
     networks:
       - morphik-network
     env_file:
-      - .env
+      - path: .env
+        required: false
 
   redis:
     image: redis:7-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       # Note: Update this port mapping to match the port in morphik.toml
       - "8000:8000"
     environment:
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-}
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-}
+      - LOCAL_URI_PASSWORD=${LOCAL_URI_PASSWORD:-}
       - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
       - PGPASSWORD=morphik
       - LOG_LEVEL=DEBUG
@@ -49,7 +51,8 @@ services:
     networks:
       - morphik-network
     env_file:
-      - .env
+      - path: .env
+        required: false
 
   worker:
     build:
@@ -57,7 +60,9 @@ services:
       dockerfile: dockerfile
     command: arq core.workers.ingestion_worker.WorkerSettings
     environment:
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-}
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY:-}
+      - LOCAL_URI_PASSWORD=${LOCAL_URI_PASSWORD:-}
       - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
       - PGPASSWORD=morphik
       - LOG_LEVEL=DEBUG
@@ -82,7 +87,8 @@ services:
     networks:
       - morphik-network
     env_file:
-      - .env
+      - path: .env
+        required: false
 
   redis:
     image: redis:7-alpine

--- a/install_docker.ps1
+++ b/install_docker.ps1
@@ -8,7 +8,7 @@
     ./install_docker.ps1
 
   Requirements:
-    - Docker Desktop running (Compose V2 included)
+    - Docker Desktop running with Docker Compose 2.24.0 or newer
     - Internet connectivity to pull the image or fetch config files
 #>
 
@@ -16,6 +16,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $script:EmbeddingSelection = $null
+$script:AuthSecretMinLength = 32
+$script:MinComposeVersion = [Version]'2.24.0'
 
 function Write-Info($msg)  { Write-Host "[INFO]  $msg" -ForegroundColor Cyan }
 function Write-Step($msg)  { Write-Host "[STEP]  $msg" -ForegroundColor Yellow }
@@ -38,9 +40,23 @@ function Assert-Docker {
     Write-Err "Docker is installed but not running. Start Docker Desktop and retry."
     throw "Docker not running"
   }
-  try { docker compose version | Out-Null } catch {
+  $composeVersionOutput = docker compose version --short 2>$null
+  if ($LASTEXITCODE -ne 0 -or -not $composeVersionOutput) {
+    $composeVersionOutput = docker compose version 2>$null
+  }
+  if ($LASTEXITCODE -ne 0 -or -not $composeVersionOutput) {
     Write-Err "Docker Compose V2 is required. Please update Docker Desktop."
     throw "Compose V2 missing"
+  }
+  $composeVersionText = ($composeVersionOutput | Out-String).Trim()
+  if ($composeVersionText -notmatch 'v?(\d+\.\d+\.\d+)') {
+    Write-Err "Could not determine Docker Compose version. Please update Docker Desktop."
+    throw "Compose version unknown"
+  }
+  $composeVersion = [Version]$Matches[1]
+  if ($composeVersion -lt $script:MinComposeVersion) {
+    Write-Err "Docker Compose $($script:MinComposeVersion) or newer is required because Morphik uses optional env_file support for .env."
+    throw "Compose too old"
   }
 }
 
@@ -65,6 +81,7 @@ function Set-EnvValue {
 
   if (-not (Test-Path '.env')) {
     Add-Content -Path .env -Value "$Key=$Value"
+    Protect-EnvFile
     return
   }
 
@@ -77,6 +94,77 @@ function Set-EnvValue {
   } else {
     Add-Content -Path .env -Value "$Key=$Value"
   }
+
+  Protect-EnvFile
+}
+
+function Protect-EnvFile {
+  if (-not (Test-Path '.env')) { return }
+
+  if ($env:OS -eq 'Windows_NT') {
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $acl = Get-Acl '.env'
+    $acl.SetAccessRuleProtection($true, $false)
+    foreach ($accessRule in @($acl.Access)) {
+      [void]$acl.RemoveAccessRuleSpecific($accessRule)
+    }
+    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule -ArgumentList $identity, 'FullControl', 'Allow'
+    $acl.SetAccessRule($rule)
+    Set-Acl -Path '.env' -AclObject $acl
+  } else {
+    chmod 600 .env
+  }
+}
+
+function Normalize-AuthSecret {
+  param([Parameter(Mandatory)] [string] $Value)
+
+  $normalized = $Value.Trim()
+  if ($normalized.Length -ge 2) {
+    $first = $normalized.Substring(0, 1)
+    $last = $normalized.Substring($normalized.Length - 1, 1)
+    if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+      $normalized = $normalized.Substring(1, $normalized.Length - 2).Trim()
+    }
+  }
+
+  return $normalized
+}
+
+function ConvertFrom-SecureInput {
+  param([Parameter(Mandatory)] [System.Security.SecureString] $Value)
+
+  $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Value)
+  try {
+    return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+  } finally {
+    if ($bstr -ne [IntPtr]::Zero) {
+      [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+  }
+}
+
+function Assert-LocalUriPassword {
+  param([Parameter(Mandatory)] [string] $Value)
+
+  $normalized = Normalize-AuthSecret -Value $Value
+  $placeholders = @(
+    'change-me-local-uri-password',
+    'local-uri-password',
+    'your-local-uri-password-here'
+  )
+
+  if ($placeholders -contains $normalized -or ($normalized.StartsWith('<') -and $normalized.EndsWith('>'))) {
+    Write-Err "LOCAL_URI_PASSWORD must not use an example or placeholder value."
+    throw "Invalid LOCAL_URI_PASSWORD"
+  }
+
+  if ($normalized.Length -lt $script:AuthSecretMinLength) {
+    Write-Err "LOCAL_URI_PASSWORD must be at least $script:AuthSecretMinLength characters before using /local/generate_uri."
+    throw "Invalid LOCAL_URI_PASSWORD"
+  }
+
+  return $normalized
 }
 
 function Add-ComposeProfile {
@@ -84,6 +172,7 @@ function Add-ComposeProfile {
 
   if (-not (Test-Path '.env')) {
     Add-Content -Path .env -Value "COMPOSE_PROFILES=$Profile"
+    Protect-EnvFile
     return
   }
 
@@ -101,9 +190,11 @@ function Add-ComposeProfile {
       }
       $lines[$index] = "COMPOSE_PROFILES=$value"
       Set-Content -Path .env -Value $lines
+      Protect-EnvFile
     }
   } else {
     Add-Content -Path .env -Value "COMPOSE_PROFILES=$Profile"
+    Protect-EnvFile
   }
 }
 
@@ -166,7 +257,8 @@ function Ensure-ComposeFile {
 
 function Ensure-EnvFile {
   Write-Step "Creating '.env' file for secrets..."
-  $jwt = "your-super-secret-key-$(New-RandomHex 16)"
+  $jwt = "morphik-jwt-$(New-RandomHex 32)"
+  $session = "morphik-session-$(New-RandomHex 32)"
   $envContent = @(
     "# Your OpenAI API key (optional - you can configure other providers in morphik.toml)",
     "OPENAI_API_KEY=",
@@ -174,10 +266,14 @@ function Ensure-EnvFile {
     "# A secret key for signing JWTs. A random one is generated for you.",
     "JWT_SECRET_KEY=$jwt",
     "",
-    "# Local URI password for secure URI generation (required for creating connection URIs)",
+    "# A secret key for signing server-side sessions. A random one is generated for you.",
+    "SESSION_SECRET_KEY=$session",
+    "",
+    "# Optional at startup; leave blank to disable /local/generate_uri, or set a 32+ character random value before using it",
     "LOCAL_URI_PASSWORD="
   ) -join [Environment]::NewLine
   Set-Content -Path .env -Value $envContent
+  Protect-EnvFile
 
   $openai = Read-Host "Enter your OpenAI API Key (or press Enter to skip)"
   if ($openai) {
@@ -317,16 +413,17 @@ function Update-AuthBypassOrPassword {
   Write-Host ""; Write-Info "Setting up authentication for your Morphik deployment:"
   Write-Info " • For external access, set a LOCAL_URI_PASSWORD."
   Write-Info " • For local-only access, press Enter to enable bypass_auth_mode."
-  $password = Read-Host "Enter a secure LOCAL_URI_PASSWORD (or press Enter to skip)"
+  $password = ConvertFrom-SecureInput -Value (Read-Host -AsSecureString "Enter a secure LOCAL_URI_PASSWORD (or press Enter to skip)")
+  $password = Normalize-AuthSecret -Value $password
   if ([string]::IsNullOrWhiteSpace($password)) {
     Write-Info "No password provided - enabling authentication bypass (bypass_auth_mode=true)."
     $content = Get-Content morphik.toml -Raw
     $content = $content -replace '(?m)^bypass_auth_mode\s*=\s*false', 'bypass_auth_mode = true'
     Set-Content morphik.toml -Value $content
   } else {
+    $password = Assert-LocalUriPassword -Value $password
     Write-Ok "LOCAL_URI_PASSWORD set - keeping production mode (bypass_auth_mode=false)."
-    (Get-Content .env -Raw) -replace 'LOCAL_URI_PASSWORD=', "LOCAL_URI_PASSWORD=$password" |
-      Set-Content .env
+    Set-EnvValue -Key "LOCAL_URI_PASSWORD" -Value $password
   }
 }
 

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -16,6 +16,8 @@ DIRECT_INSTALL_URL="https://www.morphik.ai/docs/getting-started#self-host-direct
 EMBEDDING_PROVIDER=""
 EMBEDDING_PROVIDER_LABEL=""
 MORPHIK_VERSION="latest"
+AUTH_SECRET_MIN_LENGTH=32
+MIN_COMPOSE_VERSION="2.24.0"
 
 # --- Parse Arguments ---
 while [[ $# -gt 0 ]]; do
@@ -58,6 +60,33 @@ check_command() {
     fi
 }
 
+compose_version_at_least() {
+    local version="${1#v}"
+    local minimum="${2#v}"
+
+    if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        return 1
+    fi
+    local version_major="${BASH_REMATCH[1]}"
+    local version_minor="${BASH_REMATCH[2]}"
+    local version_patch="${BASH_REMATCH[3]}"
+
+    if [[ ! "$minimum" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        return 1
+    fi
+    local minimum_major="${BASH_REMATCH[1]}"
+    local minimum_minor="${BASH_REMATCH[2]}"
+    local minimum_patch="${BASH_REMATCH[3]}"
+
+    (( version_major > minimum_major )) ||
+        (( version_major == minimum_major && version_minor > minimum_minor )) ||
+        (( version_major == minimum_major && version_minor == minimum_minor && version_patch >= minimum_patch ))
+}
+
+protect_env_file() {
+    chmod 600 .env || print_error "Failed to restrict '.env' permissions to the current user."
+}
+
 set_env_value() {
     local key="$1"
     local value="$2"
@@ -80,6 +109,57 @@ set_env_value() {
     fi
 
     echo "${key}=${value}" >> "$env_file"
+    protect_env_file
+}
+
+normalize_auth_secret() {
+    local value="$1"
+    value="$(printf '%s' "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    if [ "${#value}" -ge 2 ]; then
+        local first_char="${value:0:1}"
+        local last_char="${value:$((${#value} - 1)):1}"
+        if { [ "$first_char" = "\"" ] && [ "$last_char" = "\"" ]; } || \
+           { [ "$first_char" = "'" ] && [ "$last_char" = "'" ]; }; then
+            local inner_length=$((${#value} - 2))
+            value="${value:1:$inner_length}"
+            value="$(printf '%s' "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        fi
+    fi
+    printf '%s' "$value"
+}
+
+validate_local_uri_password() {
+    local password="$1"
+    case "$password" in
+        "change-me-local-uri-password"|"local-uri-password"|"your-local-uri-password-here")
+            print_error "LOCAL_URI_PASSWORD must not use an example or placeholder value."
+            ;;
+    esac
+
+    if [[ "$password" == \<*\> ]]; then
+        print_error "LOCAL_URI_PASSWORD must not use an example or placeholder value."
+    fi
+
+    if [ "${#password}" -lt "$AUTH_SECRET_MIN_LENGTH" ]; then
+        print_error "LOCAL_URI_PASSWORD must be at least ${AUTH_SECRET_MIN_LENGTH} characters before using /local/generate_uri."
+    fi
+}
+
+generate_auth_secret() {
+    local prefix="$1"
+    local random_hex=""
+
+    if command -v openssl &> /dev/null; then
+        random_hex="$(openssl rand -hex 32 2>/dev/null || true)"
+    elif [ -r /dev/urandom ]; then
+        random_hex="$(LC_ALL=C tr -dc 'a-f0-9' < /dev/urandom | head -c 64 || true)"
+    fi
+
+    if [ "${#random_hex}" -lt 64 ]; then
+        print_error "Could not generate a secure auth secret. Install openssl or ensure /dev/urandom is readable."
+    fi
+
+    printf '%s-%s' "$prefix" "$random_hex"
 }
 
 ensure_compose_profile() {
@@ -146,6 +226,11 @@ check_command "docker"
 if ! docker compose version &> /dev/null; then
     print_error "Docker Compose V2 is required. Please ensure it's installed and accessible."
 fi
+compose_version_output=$(docker compose version --short 2>/dev/null || docker compose version 2>/dev/null || true)
+compose_version=$(printf '%s' "$compose_version_output" | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+if [[ -z "$compose_version" ]] || ! compose_version_at_least "$compose_version" "$MIN_COMPOSE_VERSION"; then
+    print_error "Docker Compose ${MIN_COMPOSE_VERSION} or newer is required because Morphik uses optional env_file support for .env."
+fi
 print_success "Prerequisites are satisfied."
 
 # 2. Apple Silicon Warning
@@ -170,19 +255,28 @@ fi
 
 # 4. Create .env and get User Input for API Key
 print_info "Creating '.env' file for your secrets..."
+jwt_secret="$(generate_auth_secret "morphik-jwt")"
+session_secret="$(generate_auth_secret "morphik-session")"
+previous_umask="$(umask)"
+umask 077
 cat > .env <<EOF
 # Your OpenAI API key (optional - you can configure other providers in morphik.toml)
 OPENAI_API_KEY=
 
 # A secret key for signing JWTs. A random one is generated for you.
-JWT_SECRET_KEY=your-super-secret-key-that-is-long-and-random-$(openssl rand -hex 16)
+JWT_SECRET_KEY=${jwt_secret}
 
-# Local URI password for secure URI generation (required for creating connection URIs)
+# A secret key for signing server-side sessions. A random one is generated for you.
+SESSION_SECRET_KEY=${session_secret}
+
+# Optional at startup; leave blank to disable /local/generate_uri, or set a 32+ character random value before using it
 LOCAL_URI_PASSWORD=
 
 # Morphik image version (use a date tag like 2025-02-01 to pin, or "latest" for newest)
 MORPHIK_VERSION=${MORPHIK_VERSION}
 EOF
+umask "$previous_umask"
+protect_env_file
 
 print_info "Morphik supports 100s of models including OpenAI, Anthropic (Claude), Google Gemini, local models, and even custom models!"
 read -p "Please enter your OpenAI API Key (or press Enter to skip and configure later): " openai_api_key < /dev/tty
@@ -332,9 +426,11 @@ echo ""
 print_info "🔐 Setting up authentication for your Morphik deployment:"
 print_info "   • If you plan to access Morphik from outside this server, setting a LOCAL_URI_PASSWORD will secure your deployment"
 print_info "   • For local-only access, you can skip this step (bypass_auth_mode will be enabled)"
-print_info "   • With a LOCAL_URI_PASSWORD set, you'll need to use /generate_local_uri endpoint for authorization tokens"
+print_info "   • With a LOCAL_URI_PASSWORD set, you'll need to use /local/generate_uri endpoint for authorization tokens"
 echo ""
-read -p "Please enter a secure LOCAL_URI_PASSWORD (or press Enter to skip for local-only access): " local_uri_password < /dev/tty
+read -r -s -p "Please enter a secure LOCAL_URI_PASSWORD (or press Enter to skip for local-only access): " local_uri_password < /dev/tty
+echo ""
+local_uri_password="$(normalize_auth_secret "$local_uri_password")"
 if [[ -z "$local_uri_password" ]]; then
     print_info "No LOCAL_URI_PASSWORD provided - enabling authentication bypass (bypass_auth_mode=true) for local access"
     print_info "This is suitable for local development and testing"
@@ -346,15 +442,14 @@ if [[ -z "$local_uri_password" ]]; then
         print_warning "morphik.toml not found, cannot set bypass_auth_mode"
     fi
 else
+    validate_local_uri_password "$local_uri_password" || exit 1
     print_success "LOCAL_URI_PASSWORD set - keeping production mode (bypass_auth_mode=false) with authentication enabled"
-    print_info "Use the /generate_local_uri endpoint with this password to create authorized connection URIs"
+    print_info "Use the /local/generate_uri endpoint with this password to create authorized connection URIs"
 fi
 
 # Only update .env if a password was provided
 if [[ -n "$local_uri_password" ]]; then
-    # Use sed to safely replace the password in the .env file.
-    sed -i.bak "s|LOCAL_URI_PASSWORD=|LOCAL_URI_PASSWORD=$local_uri_password|" .env
-    rm -f .env.bak
+    set_env_value "LOCAL_URI_PASSWORD" "$local_uri_password"
     print_success "'.env' file has been configured with your LOCAL_URI_PASSWORD."
 fi
 


### PR DESCRIPTION
## Summary

This hardens authenticated self-hosted Docker setups by requiring non-placeholder signing secrets of at least 32 characters when `bypass_auth_mode = false`. The Docker installers now generate a `SESSION_SECRET_KEY` alongside the existing generated JWT secret, Docker Compose no longer falls back to a placeholder JWT secret, and startup validation rejects missing, blank, placeholder, or too-short JWT/session signing secrets.

`LOCAL_URI_PASSWORD` remains optional at startup because blank or unset values disable `/local/generate_uri`, but if it is configured, the app and hosted Docker installers now reject placeholder or too-short values before serving requests.

The Docker guide and hosted installers now require Docker Compose 2.24.0 or newer so `.env` can be optional while shell/CI secret injection continues to work. The Docker quick start also now creates `.env` before `docker compose up --build` so new users get both required signing secrets before startup.

## Changes

- Generate `SESSION_SECRET_KEY` in both hosted Docker installers.
- Restrict hosted Docker `.env` files to the current user after creation and updates, including stricter Windows ACL cleanup.
- Hide `LOCAL_URI_PASSWORD` terminal input in the hosted Docker installers.
- Remove the Compose-level `JWT_SECRET_KEY:-your-secret-key-here` fallback and pass through auth secrets explicitly from `.env` or the shell.
- Keep `.env` optional in Compose so CI and secret-manager workflows can still inject `JWT_SECRET_KEY`, `SESSION_SECRET_KEY`, and `LOCAL_URI_PASSWORD` through the process environment.
- Require Docker Compose 2.24.0+ in Docker docs and hosted installers because optional `env_file` support is used.
- Update the Docker quick start to create `.env` with separate generated JWT and session secrets before the first Compose run.
- Validate `JWT_SECRET_KEY` and `SESSION_SECRET_KEY` when auth bypass is disabled.
- Validate configured `LOCAL_URI_PASSWORD` values while keeping a missing/blank local URI password as the disabled state for `/local/generate_uri`.
- Return an explicit disabled response from `/local/generate_uri` when `LOCAL_URI_PASSWORD` is blank or unset.
- Update Docker docs to mention the session secret requirement, local URI password behavior, and auth-secret troubleshooting.
- Add focused unit/static tests for config validation, installer generation, optional Compose `.env` wiring, shell-secret injection, installer validation failure behavior, endpoint disabled behavior, and Docker docs.

## Why this matters

Self-hosted Docker deployments with authentication enabled should not silently use shared development signing secrets. Missing or placeholder session signing keys are especially risky because Starlette sessions depend on `SESSION_SECRET_KEY`, while the old Compose JWT fallback could hide a missing production secret from runtime validation.

## Tests

Commands run:

- `.venv/bin/python -m pytest core/tests/unit/test_config_auth_secrets.py core/tests/unit/test_installer_auth_env.py -q` — passed (`58 passed, 1 skipped`)
- `bash -n install_docker.sh && bash -n install_and_start.sh` — passed
- `.venv/bin/python -m py_compile core/config.py core/api.py core/local_uri.py core/tests/unit/test_config_auth_secrets.py core/tests/unit/test_installer_auth_env.py` — passed
- `uv run ty check core/tests/unit/test_installer_auth_env.py core/tests/unit/test_config_auth_secrets.py core/local_uri.py` — passed
- `git diff --check` — passed

Not run successfully:

- `uv run ruff check core/config.py core/api.py core/tests/unit/test_config_auth_secrets.py core/tests/unit/test_installer_auth_env.py` — failed because `ruff` is not installed in the local project environment.
- `uv run ruff format --check core/config.py core/api.py core/tests/unit/test_config_auth_secrets.py core/tests/unit/test_installer_auth_env.py` — failed because `ruff` is not installed in the local project environment.
- PowerShell parser execution — skipped locally because neither `pwsh` nor `powershell` is installed. The test is present and will run where PowerShell is available.

## Risk

Risk level: medium

This intentionally changes startup behavior for `bypass_auth_mode = false`: missing, blank, placeholder, or short JWT/session signing secrets now fail fast instead of falling back to unsafe defaults. Missing/blank `LOCAL_URI_PASSWORD` remains compatible as the disabled state for `/local/generate_uri`; only configured placeholder or too-short local URI passwords now fail validation. Rollback is straightforward by reverting this commit, but doing so would restore unsafe fallback behavior.

## Issue

No existing issue. This was discovered during repository analysis and follow-up security review of the self-hosted Docker path.

## Notes for maintainers

- This PR does not change the direct installers.
- This PR keeps environment-variable based Docker secret delivery; moving production Docker secrets to Docker secrets or an external secret manager would be a separate deployment-hardening follow-up.
