### PR TITLE
fix: preserve SDK imports on supported Python versions

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Restored SDK import and test collection compatibility on Python 3.9 by avoiding newer runtime annotation syntax.
+
 ## [1.2.6] - 2026-06-19
 
 ### Changed

--- a/sdks/python/morphik/_internal.py
+++ b/sdks/python/morphik/_internal.py
@@ -26,7 +26,7 @@ from .models import (
 
 
 class FinalChunkResult(BaseModel):
-    content: str | PILImage = Field(..., description="Chunk content")
+    content: Union[str, PILImage] = Field(..., description="Chunk content")
     score: float = Field(..., description="Relevance score")
     document_id: str = Field(..., description="Parent document ID")
     chunk_number: int = Field(..., description="Chunk sequence number")

--- a/sdks/python/morphik/async_.py
+++ b/sdks/python/morphik/async_.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from io import BytesIO
 from pathlib import Path
-from typing import Any, BinaryIO, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import Any, BinaryIO, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 from urllib.parse import quote
 
 import httpx
@@ -1441,7 +1441,7 @@ class AsyncMorphik(_ScopedOperationsMixin):
         end_user_id: Optional[str],
         use_colpali: bool,
         on_conflict: Literal["skip", "fail"],
-    ) -> tuple[str, Document]:
+    ) -> Tuple[str, Document]:
         serialized_metadata, inferred_types = self._logic._serialize_metadata_map(metadata)
         metadata_type_payload = {**inferred_types, **(metadata_types or {})}
         metadata_type_payload = {

--- a/sdks/python/morphik/sync.py
+++ b/sdks/python/morphik/sync.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 from io import BytesIO
 from pathlib import Path
-from typing import Any, BinaryIO, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import Any, BinaryIO, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 from urllib.parse import quote
 
 import httpx
@@ -1483,7 +1483,7 @@ class Morphik(_ScopedOperationsMixin):
         end_user_id: Optional[str],
         use_colpali: bool,
         on_conflict: Literal["skip", "fail"],
-    ) -> tuple[str, Document]:
+    ) -> Tuple[str, Document]:
         serialized_metadata, inferred_types = self._logic._serialize_metadata_map(metadata)
         metadata_type_payload = {**inferred_types, **(metadata_types or {})}
         metadata_type_payload = {

--- a/sdks/python/morphik/tests/test_async.py
+++ b/sdks/python/morphik/tests/test_async.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import uuid
 from pathlib import Path
+from typing import List
 
 import pytest
 from morphik.async_ import AsyncMorphik
@@ -22,7 +23,7 @@ TEST_DOCS_DIR = Path(__file__).parent / "test_docs"
 
 class StructuredOutputSchema(BaseModel):
     summary: str = Field(..., description="A short summary of the input text")
-    key_points: list[str] = Field(..., description="A list of key points from the text")
+    key_points: List[str] = Field(..., description="A list of key points from the text")
 
 
 class TestAsyncMorphik:

--- a/sdks/python/morphik/tests/test_sync.py
+++ b/sdks/python/morphik/tests/test_sync.py
@@ -2,6 +2,7 @@ import os
 import time
 import uuid
 from pathlib import Path
+from typing import List
 
 import pytest
 from morphik.sync import Morphik
@@ -22,7 +23,7 @@ TEST_DOCS_DIR = Path(__file__).parent / "test_docs"
 
 class StructuredOutputSchema(BaseModel):
     summary: str = Field(..., description="A short summary of the input text")
-    key_points: list[str] = Field(..., description="A list of key points from the text")
+    key_points: List[str] = Field(..., description="A list of key points from the text")
 
 
 class TestMorphik:


### PR DESCRIPTION
## Summary

The Python SDK declares `requires-python = ">=3.8"`, but a few runtime-evaluated annotations used newer Python syntax. On Python 3.9, importing `morphik` failed immediately with `TypeError: unsupported operand type(s) for |: 'type' and 'type'` before users could create a client.

This replaces those annotations with `typing` equivalents (`Union`, `Tuple`, and `List`) and adds a short SDK changelog note. There is no API behavior change.

## Changes

- Replaced `FinalChunkResult.content: str | PILImage` with `Union[str, PILImage]`.
- Replaced sync/async migration helper return annotations from `tuple[str, Document]` to `Tuple[str, Document]`.
- Replaced live-test schema annotations from `list[str]` to `List[str]` so those modules collect on older supported interpreters.
- Added an `Unreleased` Python SDK changelog entry for the compatibility fix.

## Why this matters

Users on Python versions allowed by the SDK metadata should be able to import the package. This fixes a reproduced import-time compatibility regression for Python 3.9 and removes the same newer annotation forms from the touched SDK/test surface.

## Tests

Commands run:

- `uv run --python 3.9 --with pytest --with httpx --with pyjwt --with 'pydantic>=2.10.3' --with 'pillow>=10.4.0' --project sdks/python python - <<'PY' ... import morphik ... PY` — failed before the fix with `TypeError: unsupported operand type(s) for |: 'type' and 'type'`.
- `uv run --python 3.9 --project sdks/python python -c "import morphik; from morphik.sync import Morphik; from morphik.async_ import AsyncMorphik; print('py39 import ok')"` — passed.
- `uv run --python 3.9 --project sdks/python pytest sdks/python/morphik/tests/test_scoped_ops_unit.py::test_sync_client_accepts_plain_http_uri_without_auth -q` — passed.
- `SKIP_LIVE_TESTS=1 uv run --python 3.9 --project sdks/python pytest sdks/python/morphik/tests/test_sync.py sdks/python/morphik/tests/test_async.py --collect-only -q` — passed, 26 tests collected.
- `.venv/bin/python -m pytest sdks/python/morphik/tests/test_scoped_ops_unit.py -q` — passed, 49 tests.
- `SKIP_LIVE_TESTS=1 .venv/bin/python -m pytest sdks/python/morphik/tests -q` — passed, 74 passed / 26 skipped.
- `.venv/bin/python -m py_compile sdks/python/morphik/_internal.py sdks/python/morphik/sync.py sdks/python/morphik/async_.py sdks/python/morphik/tests/test_sync.py sdks/python/morphik/tests/test_async.py` — passed.
- Python 3.8 grammar parse across `sdks/python/morphik/**/*.py` using `ast.parse(..., feature_version=(3, 8))` — passed.
- SDK annotation compatibility scan for PEP 604 unions and PEP 585 builtin generic annotations under `sdks/python/morphik` — passed.
- `.venv/bin/markdown-it sdks/python/CHANGELOG.md >/tmp/sdk-changelog-pr12.html` — passed.
- `git diff --check` — passed.

Checks not completed:

- `uv run --python 3.8 --project sdks/python ...` — not completed because the local `cpython-3.8.20-macos-aarch64` download remained silent for multiple minutes and was interrupted. The Python 3.9 runtime failure is reproduced/fixed, and source-level Python 3.8 grammar/annotation scans pass.
- `uv run ty check ...` — failed on existing SDK typing diagnostics unrelated to this diff (`_prepare_file_for_upload` return type, `CompletionResponse` required `usage`, sync/async `get_info` return type, and migration status literal).
- `uv run ruff check ...` — not run successfully because `ruff` is not installed in the local project environment.

## Risk

Risk level: low.

This is an annotation-only compatibility fix plus a changelog entry. It does not change request payloads, parsing behavior, public APIs, dependencies, auth, or network behavior. Rollback is straightforward if maintainers choose to raise the SDK Python floor instead.

## Issue

No existing issue. This was discovered during repository analysis.

This does not address or close issue #155, which concerns a hosted documentation redirect page that is not present in this repository.

## Notes for maintainers

Follow-up worth considering: add a small SDK import/test-collection CI job for the declared minimum supported Python version, so future annotation syntax regressions are caught automatically.
