### PR TITLE
fix: honor Redis DSN during API startup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,28 @@ jobs:
           echo "=== After cleanup ==="
           df -h
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Test Redis settings regression
+        run: >
+          uv run --no-project
+          --with pytest
+          --with pytest-asyncio
+          --with arq
+          --with fastapi
+          --with pydantic-settings
+          --with tomli
+          --with requests
+          --with uvicorn
+          --with python-dotenv
+          pytest -q core/tests/unit/test_redis_settings.py
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import arq
 from fastapi import FastAPI
 
+from core.redis_settings import build_redis_settings
+
 HEARTBEAT_URL = "https://logs.morphik.ai/api/heartbeat"
 HEARTBEAT_INTERVAL_HOURS = 4.0
 
@@ -89,14 +91,13 @@ async def lifespan(app_instance: FastAPI):
     logger.info("Lifespan: Attempting to initialize Redis connection pool…")
     global _global_redis_pool  # pylint: disable=global-statement
     try:
-        redis_settings_obj = arq.connections.RedisSettings(
-            host=settings.REDIS_HOST,
-            port=settings.REDIS_PORT,
-        )
+        redis_settings_obj = build_redis_settings(settings)
         logger.info(
-            "Lifespan: Redis settings for pool: host=%s, port=%s",
-            settings.REDIS_HOST,
-            settings.REDIS_PORT,
+            "Lifespan: Redis settings for pool: host=%s, port=%s, database=%s, ssl=%s",
+            redis_settings_obj.host,
+            redis_settings_obj.port,
+            redis_settings_obj.database,
+            redis_settings_obj.ssl,
         )
         current_redis_pool = await arq.create_pool(redis_settings_obj)
         if current_redis_pool:

--- a/core/config.py
+++ b/core/config.py
@@ -145,6 +145,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/0"
     REDIS_HOST: str = "localhost"
     REDIS_PORT: int = 6379
+    REDIS_SSL_CHECK_HOSTNAME: Optional[bool] = None
 
     # Worker configuration
     ARQ_MAX_JOBS: int = 1
@@ -407,6 +408,8 @@ def get_settings() -> Settings:
                 "REDIS_PORT": redis_cfg.get("port", 6379),
             }
         )
+        if "ssl_check_hostname" in redis_cfg:
+            settings_dict["REDIS_SSL_CHECK_HOSTNAME"] = redis_cfg["ssl_check_hostname"]
 
     # Load worker config
     if "worker" in config:

--- a/core/redis_settings.py
+++ b/core/redis_settings.py
@@ -1,0 +1,111 @@
+"""Shared Redis connection settings for API startup and ARQ workers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from arq.connections import RedisSettings
+
+DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+DEFAULT_REDIS_HOST = "localhost"
+DEFAULT_REDIS_PORT = 6379
+
+LOCAL_REDIS_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_MISSING = object()
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _allow_insecure_remote_redis(settings: Any) -> bool:
+    setting_value = getattr(settings, "ALLOW_INSECURE_REMOTE_REDIS", None)
+    if setting_value is None:
+        setting_value = os.getenv("ALLOW_INSECURE_REMOTE_REDIS", "")
+    return str(setting_value).strip().lower() in _TRUE_VALUES
+
+
+def _optional_bool(value: Any, name: str) -> bool | None:
+    if value is None or value is _MISSING:
+        return None
+    if isinstance(value, bool):
+        return value
+
+    normalized = str(value).strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise ValueError(f"{name} must be a boolean value")
+
+
+def _is_default_local_redis_target(redis_settings: RedisSettings) -> bool:
+    return (
+        redis_settings.host in LOCAL_REDIS_HOSTS
+        and redis_settings.port == DEFAULT_REDIS_PORT
+        and redis_settings.database == 0
+        and not redis_settings.unix_socket_path
+        and not redis_settings.username
+        and not redis_settings.password
+        and not redis_settings.ssl
+    )
+
+
+def build_redis_settings(settings: Any) -> RedisSettings:
+    """Build ARQ Redis settings from Morphik settings.
+
+    `REDIS_URL` is the canonical source because it can carry authentication,
+    database selection, and TLS. The host/port fallback preserves the existing
+    `morphik.toml` behavior where deployments override only those fields while
+    leaving the default localhost URL in place.
+    """
+    raw_redis_url = getattr(settings, "REDIS_URL", _MISSING)
+    if raw_redis_url is _MISSING:
+        redis_url = DEFAULT_REDIS_URL
+    elif raw_redis_url is None:
+        raise ValueError("REDIS_URL is set but empty; expected a valid Redis DSN")
+    else:
+        redis_url = str(raw_redis_url).strip()
+        if not redis_url:
+            raise ValueError("REDIS_URL is set but empty; expected a valid Redis DSN")
+
+    redis_settings = RedisSettings.from_dsn(redis_url)
+    if (
+        not redis_settings.ssl
+        and redis_settings.host not in LOCAL_REDIS_HOSTS
+        and (redis_settings.username or redis_settings.password)
+        and not _allow_insecure_remote_redis(settings)
+    ):
+        raise ValueError(
+            "Authenticated remote Redis must use rediss://; set ALLOW_INSECURE_REMOTE_REDIS=true to allow "
+            "plaintext Redis credentials"
+        )
+    ssl_check_hostname = _optional_bool(getattr(settings, "REDIS_SSL_CHECK_HOSTNAME", _MISSING), "REDIS_SSL_CHECK_HOSTNAME")
+    if redis_settings.ssl and ssl_check_hostname is not None:
+        redis_settings.ssl_check_hostname = ssl_check_hostname
+
+    redis_host = getattr(settings, "REDIS_HOST", DEFAULT_REDIS_HOST)
+    redis_port = getattr(settings, "REDIS_PORT", DEFAULT_REDIS_PORT)
+
+    if _is_default_local_redis_target(redis_settings) and (
+        redis_host != DEFAULT_REDIS_HOST or redis_port != DEFAULT_REDIS_PORT
+    ):
+        redis_settings.host = redis_host
+        redis_settings.port = redis_port
+
+    # Keep worker/API pool behavior aligned and stable under transient startup races.
+    redis_settings.conn_timeout = 5
+    redis_settings.conn_retries = 15
+    redis_settings.conn_retry_delay = 1
+    return redis_settings
+
+
+def should_manage_local_redis(redis_settings: RedisSettings) -> bool:
+    """Return true when `start_server.py` should manage a local Redis container."""
+    return (
+        redis_settings.host in LOCAL_REDIS_HOSTS
+        and redis_settings.port == DEFAULT_REDIS_PORT
+        and not redis_settings.unix_socket_path
+        and not redis_settings.username
+        and not redis_settings.password
+        and not redis_settings.ssl
+    )

--- a/core/tests/unit/test_redis_settings.py
+++ b/core/tests/unit/test_redis_settings.py
@@ -1,0 +1,366 @@
+import atexit
+import importlib
+import signal
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from core.redis_settings import DEFAULT_REDIS_URL, build_redis_settings, should_manage_local_redis
+
+
+def test_build_redis_settings_preserves_dsn_auth_database_and_tls():
+    settings = SimpleNamespace(
+        REDIS_URL="rediss://user:secret@redis.example.com:6380/3",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+    )
+
+    redis_settings = build_redis_settings(settings)
+
+    assert redis_settings.host == "redis.example.com"
+    assert redis_settings.port == 6380
+    assert redis_settings.database == 3
+    assert redis_settings.username == "user"
+    assert redis_settings.password == "secret"
+    assert redis_settings.ssl is True
+    assert redis_settings.ssl_check_hostname is False
+    assert redis_settings.conn_timeout == 5
+    assert redis_settings.conn_retries == 15
+    assert redis_settings.conn_retry_delay == 1
+
+
+def test_build_redis_settings_allows_hostname_verification_opt_in_for_tls():
+    settings = SimpleNamespace(
+        REDIS_URL="rediss://user:secret@redis.example.com:6380/3",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+        REDIS_SSL_CHECK_HOSTNAME=True,
+    )
+
+    redis_settings = build_redis_settings(settings)
+
+    assert redis_settings.ssl is True
+    assert redis_settings.ssl_check_hostname is True
+
+
+def test_build_redis_settings_rejects_empty_url():
+    settings = SimpleNamespace(
+        REDIS_URL=" ",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+    )
+
+    with pytest.raises(ValueError, match="REDIS_URL is set but empty"):
+        build_redis_settings(settings)
+
+
+def test_build_redis_settings_rejects_plaintext_remote_credentials_by_default():
+    settings = SimpleNamespace(
+        REDIS_URL="redis://:secret@redis.example.com:6380/2",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+    )
+
+    with pytest.raises(ValueError, match="Authenticated remote Redis must use rediss://"):
+        build_redis_settings(settings)
+
+
+def test_build_redis_settings_allows_plaintext_remote_credentials_with_explicit_override():
+    settings = SimpleNamespace(
+        REDIS_URL="redis://:secret@redis.example.com:6380/2",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+        ALLOW_INSECURE_REMOTE_REDIS=True,
+    )
+
+    redis_settings = build_redis_settings(settings)
+
+    assert redis_settings.host == "redis.example.com"
+    assert redis_settings.port == 6380
+    assert redis_settings.database == 2
+    assert redis_settings.password == "secret"
+    assert redis_settings.ssl is False
+
+
+def test_build_redis_settings_preserves_host_port_fallback_for_default_url():
+    settings = SimpleNamespace(
+        REDIS_URL=DEFAULT_REDIS_URL,
+        REDIS_HOST="redis",
+        REDIS_PORT=6381,
+    )
+
+    redis_settings = build_redis_settings(settings)
+
+    assert redis_settings.host == "redis"
+    assert redis_settings.port == 6381
+    assert redis_settings.database == 0
+    assert redis_settings.password is None
+    assert redis_settings.ssl is False
+
+
+def test_build_redis_settings_applies_host_port_fallback_for_equivalent_default_url():
+    settings = SimpleNamespace(
+        REDIS_URL="redis://localhost:6379",
+        REDIS_HOST="redis",
+        REDIS_PORT=6381,
+    )
+
+    redis_settings = build_redis_settings(settings)
+
+    assert redis_settings.host == "redis"
+    assert redis_settings.port == 6381
+    assert redis_settings.database == 0
+    assert redis_settings.password is None
+    assert redis_settings.ssl is False
+
+
+def test_should_manage_local_redis_only_for_default_local_target():
+    local_settings = build_redis_settings(
+        SimpleNamespace(
+            REDIS_URL=DEFAULT_REDIS_URL,
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+        )
+    )
+    local_nonzero_db_settings = build_redis_settings(
+        SimpleNamespace(
+            REDIS_URL="redis://localhost:6379/2",
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+        )
+    )
+    external_settings = build_redis_settings(
+        SimpleNamespace(
+            REDIS_URL="rediss://:secret@redis.example.com:6380/2",
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+        )
+    )
+
+    assert should_manage_local_redis(local_settings) is True
+    assert should_manage_local_redis(local_nonzero_db_settings) is True
+    assert should_manage_local_redis(external_settings) is False
+
+
+def test_should_not_manage_local_redis_for_unix_socket_dsn():
+    redis_settings = build_redis_settings(
+        SimpleNamespace(
+            REDIS_URL="unix:///tmp/morphik-redis.sock",
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+        )
+    )
+
+    assert redis_settings.unix_socket_path == "/tmp/morphik-redis.sock"
+    assert should_manage_local_redis(redis_settings) is False
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_uses_shared_redis_settings(monkeypatch):
+    import core.app_factory as app_factory
+
+    captured = {}
+
+    class FakePool:
+        def close(self):
+            captured["closed"] = True
+
+    class AsyncInitializable:
+        async def initialize(self):
+            return True
+
+    services_init = types.ModuleType("core.services_init")
+    for name, value in {
+        "database": AsyncInitializable(),
+        "vector_store": AsyncInitializable(),
+        "v2_chunk_store": AsyncInitializable(),
+        "colpali_vector_store": None,
+        "settings": SimpleNamespace(
+            REDIS_URL="rediss://:secret@redis.example.com:6380/2",
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+            TELEMETRY_ENABLED=False,
+        ),
+    }.items():
+        setattr(services_init, name, value)
+    monkeypatch.setitem(sys.modules, "core.services_init", services_init)
+
+    async def fake_create_pool(redis_settings):
+        captured["redis_settings"] = redis_settings
+        return FakePool()
+
+    monkeypatch.setattr(app_factory.arq, "create_pool", fake_create_pool)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with app_factory.lifespan(app):
+        redis_settings = captured["redis_settings"]
+        assert redis_settings.host == "redis.example.com"
+        assert redis_settings.port == 6380
+        assert redis_settings.database == 2
+        assert redis_settings.password == "secret"
+        assert redis_settings.ssl is True
+        assert redis_settings.ssl_check_hostname is False
+        assert app.state.redis_pool is not None
+
+    assert captured["closed"] is True
+
+
+def test_wait_for_redis_uses_dsn_settings_for_connection(monkeypatch):
+    import start_server
+
+    captured = {}
+    redis_settings = build_redis_settings(
+        SimpleNamespace(
+            REDIS_URL="rediss://user:secret@redis.example.com:6380/2",
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+        )
+    )
+
+    class FakePool:
+        async def ping(self):
+            captured["pinged"] = True
+
+        async def aclose(self):
+            captured["closed"] = True
+
+    async def fake_create_pool(settings):
+        captured["settings"] = settings
+        return FakePool()
+
+    monkeypatch.setattr(start_server.arq, "create_pool", fake_create_pool)
+
+    assert start_server.wait_for_redis(redis_settings, timeout=3) is True
+
+    readiness_settings = captured["settings"]
+    assert readiness_settings.host == "redis.example.com"
+    assert readiness_settings.port == 6380
+    assert readiness_settings.database == 2
+    assert readiness_settings.username == "user"
+    assert readiness_settings.password == "secret"
+    assert readiness_settings.ssl is True
+    assert readiness_settings.ssl_check_hostname is False
+    assert readiness_settings.conn_timeout == 1
+    assert readiness_settings.conn_retries == 0
+    assert captured["pinged"] is True
+    assert captured["closed"] is True
+
+
+def test_wait_for_redis_respects_timeout_deadline(monkeypatch):
+    import start_server
+
+    attempts = []
+    sleeps = []
+    now = {"value": 0.0}
+    redis_settings = build_redis_settings(
+        SimpleNamespace(
+            REDIS_URL="rediss://redis.example.com:6380/2",
+            REDIS_HOST="localhost",
+            REDIS_PORT=6379,
+        )
+    )
+
+    async def fake_create_pool(settings):
+        attempts.append(settings)
+        now["value"] += 0.4
+        raise OSError("redis unavailable")
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        now["value"] += seconds
+
+    monkeypatch.setattr(start_server.arq, "create_pool", fake_create_pool)
+    monkeypatch.setattr(start_server.time, "monotonic", lambda: now["value"])
+    monkeypatch.setattr(start_server.time, "sleep", fake_sleep)
+
+    assert start_server.wait_for_redis(redis_settings, timeout=1) is False
+    assert len(attempts) == 1
+    assert attempts[0].conn_retries == 0
+    assert sleeps == [0.6]
+    assert now["value"] == pytest.approx(1.0)
+
+
+def test_start_server_import_has_no_shutdown_handler_side_effects(monkeypatch):
+    int_handler = signal.getsignal(signal.SIGINT)
+    term_handler = signal.getsignal(signal.SIGTERM)
+    signal_calls = []
+    atexit_calls = []
+
+    monkeypatch.delitem(sys.modules, "start_server", raising=False)
+    monkeypatch.setattr(signal, "signal", lambda *args: signal_calls.append(args))
+    monkeypatch.setattr(atexit, "register", lambda *args: atexit_calls.append(args))
+    start_server = importlib.import_module("start_server")
+
+    assert signal.getsignal(signal.SIGINT) is int_handler
+    assert signal.getsignal(signal.SIGTERM) is term_handler
+    assert signal_calls == []
+    assert atexit_calls == []
+    monkeypatch.setitem(sys.modules, "start_server", start_server)
+
+
+def test_start_server_skips_local_container_management_for_external_dsn(monkeypatch):
+    import start_server
+
+    calls = []
+    settings = SimpleNamespace(
+        REDIS_URL="rediss://:secret@redis.example.com:6380/2",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+        HOST="127.0.0.1",
+        PORT=8000,
+    )
+
+    monkeypatch.setattr(sys, "argv", ["start_server.py", "--skip-ollama-check"])
+    monkeypatch.setattr(start_server, "register_shutdown_handlers", lambda: None)
+    monkeypatch.setattr(start_server, "setup_logging", lambda log_level: None)
+    monkeypatch.setattr(start_server, "load_local_env", lambda override: None)
+    monkeypatch.setattr(start_server, "get_settings", lambda: settings)
+    monkeypatch.setattr(start_server, "check_and_start_redis", lambda: calls.append("manage-redis"))
+    monkeypatch.setattr(
+        start_server,
+        "wait_for_redis",
+        lambda redis_settings: calls.append(("wait", redis_settings.host, redis_settings.port)) or True,
+    )
+    monkeypatch.setattr(start_server, "start_arq_worker", lambda: calls.append("worker"))
+    monkeypatch.setattr(start_server.uvicorn, "run", lambda *args, **kwargs: calls.append(("uvicorn", kwargs)))
+
+    start_server.main()
+
+    assert "manage-redis" not in calls
+    assert ("wait", "redis.example.com", 6380) in calls
+    assert "worker" in calls
+
+
+def test_start_server_manages_local_container_for_local_nonzero_db(monkeypatch):
+    import start_server
+
+    calls = []
+    settings = SimpleNamespace(
+        REDIS_URL="redis://localhost:6379/2",
+        REDIS_HOST="localhost",
+        REDIS_PORT=6379,
+        HOST="127.0.0.1",
+        PORT=8000,
+    )
+
+    monkeypatch.setattr(sys, "argv", ["start_server.py", "--skip-ollama-check"])
+    monkeypatch.setattr(start_server, "register_shutdown_handlers", lambda: None)
+    monkeypatch.setattr(start_server, "setup_logging", lambda log_level: None)
+    monkeypatch.setattr(start_server, "load_local_env", lambda override: None)
+    monkeypatch.setattr(start_server, "get_settings", lambda: settings)
+    monkeypatch.setattr(start_server, "check_and_start_redis", lambda: calls.append("manage-redis"))
+    monkeypatch.setattr(
+        start_server,
+        "wait_for_redis",
+        lambda redis_settings: calls.append(("wait", redis_settings.host, redis_settings.port)) or True,
+    )
+    monkeypatch.setattr(start_server, "start_arq_worker", lambda: calls.append("worker"))
+    monkeypatch.setattr(start_server.uvicorn, "run", lambda *args, **kwargs: calls.append(("uvicorn", kwargs)))
+
+    start_server.main()
+
+    assert "manage-redis" in calls
+    assert ("wait", "localhost", 6379) in calls
+    assert "worker" in calls

--- a/core/workers/ingestion_worker.py
+++ b/core/workers/ingestion_worker.py
@@ -25,6 +25,7 @@ from core.limits_utils import check_and_increment_limits, estimate_pages_by_char
 from core.models.auth import AuthContext
 from core.models.chunk import Chunk
 from core.parser.morphik_parser import MorphikParser
+from core.redis_settings import build_redis_settings
 from core.services.ingestion_service import IngestionService, PdfConversionError
 from core.services.telemetry import TelemetryService
 from core.services.v2_document_service import V2DocumentService
@@ -1911,32 +1912,15 @@ async def shutdown(ctx):
 
 def redis_settings_from_env() -> RedisSettings:
     """
-    Create RedisSettings from REDIS_URL for the ARQ worker.
+    Build ARQ worker Redis settings from the shared Morphik settings helper.
 
-    Parses the full DSN (host, port, db, username/password, TLS) so workers on
-    other machines can point at an authenticated/managed Redis (e.g.
-    ElastiCache). The old host/port-only construction silently dropped
-    credentials from the URL.
+    The helper parses the full DSN for managed Redis deployments while preserving
+    the legacy host/port fallback for the default local URL.
 
     Returns:
         RedisSettings configured for Redis connection with optimized performance
     """
-    redis_settings = RedisSettings.from_dsn(settings.REDIS_URL)
-
-    # Fall back to explicit host/port settings when the URL is the localhost
-    # default but morphik.toml overrides host and/or port separately.
-    if settings.REDIS_URL == "redis://localhost:6379/0" and (
-        settings.REDIS_HOST != "localhost" or settings.REDIS_PORT != 6379
-    ):
-        redis_settings.host = settings.REDIS_HOST
-        redis_settings.port = settings.REDIS_PORT
-
-    # Use ARQ's supported parameters with optimized values for stability
-    # For high-volume ingestion (100+ documents), these settings help prevent timeouts
-    redis_settings.conn_timeout = 5  # Increased connection timeout (seconds)
-    redis_settings.conn_retries = 15  # More retries for transient connection issues
-    redis_settings.conn_retry_delay = 1  # Quick retry delay (seconds)
-    return redis_settings
+    return build_redis_settings(settings)
 
 
 # ARQ Worker Settings

--- a/install_and_start.ps1
+++ b/install_and_start.ps1
@@ -7,8 +7,8 @@
     ./install_and_start.ps1
 
   Requirements:
-    - Docker Desktop running (used for local Redis container and optional services)
     - Python 3.10+ (3.12 recommended)
+    - Docker Desktop running when using the default local Redis configuration
 #>
 
 Set-StrictMode -Version Latest
@@ -18,18 +18,6 @@ function Write-Info($msg) { Write-Host "`n[INFO] $msg" -ForegroundColor Cyan }
 function Write-Step($msg) { Write-Host "`n[STEP] $msg" -ForegroundColor Yellow }
 function Write-Ok($msg)   { Write-Host "`n[OK]   $msg" -ForegroundColor Green }
 function Write-Err($msg)  { Write-Host "`n[ERR]  $msg" -ForegroundColor Red }
-
-function Assert-Docker {
-  if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
-    Write-Err "Docker is required (used to run a local Redis container). Install Docker Desktop first."
-    throw "Docker not found"
-  }
-  cmd.exe /c "docker info >NUL 2>&1"
-  if ($LASTEXITCODE -ne 0) {
-    Write-Err "Docker is installed but not running. Please start Docker Desktop and re-run."
-    throw "Docker not running"
-  }
-}
 
 function Ensure-Uv {
   $uvCmd = Get-Command uv -ErrorAction SilentlyContinue
@@ -111,32 +99,29 @@ $arch = $env:PROCESSOR_ARCHITECTURE
 if (-not $arch) { $arch = "unknown" }
 Write-Info "Detected OS: Windows | Arch: $arch"
 
-# 1) Check Docker
-Assert-Docker
-
-# 2) Ensure uv is available
+# 1) Ensure uv is available
 Ensure-Uv
 
-# 3) Create/Sync virtual environment and install project deps
+# 2) Create/Sync virtual environment and install project deps
 Write-Step "Installing project dependencies with uv..."
 $py312 = Ensure-Py312
 uv sync --python $py312
 
-# 4) Ensure .env exists
+# 3) Ensure .env exists
 Ensure-EnvFile
 
-# 4b) Ensure we install into the project's venv (not a global Conda/Python)
+# 3b) Ensure we install into the project's venv (not a global Conda/Python)
 $venvPython = Join-Path (Get-Location) '.venv\Scripts\python.exe'
 if (-not (Test-Path $venvPython)) {
   Write-Err "Project virtual environment was not created at .venv. Please re-run 'uv sync'."
   throw ".venv not found"
 }
 
-# 5) Install ColPali engine (multimodal search)
+# 4) Install ColPali engine (multimodal search)
 Write-Step "Installing ColPali engine..."
 uv pip install --python $venvPython `
   colpali-engine@git+https://github.com/illuin-tech/colpali@80fb72c9b827ecdb5687a3a8197077d0d01791b3
 
-# 6) Start the server
+# 5) Start the server
 Write-Host "`nStarting Morphik server...`n" -ForegroundColor Green
 uv run --python $venvPython start_server.py

--- a/install_and_start.sh
+++ b/install_and_start.sh
@@ -3,18 +3,13 @@
 # Morphik Core one-liner installer + server launcher.
 # Works on macOS (Apple Silicon or Intel) and Linux.
 # Usage:  bash install_and_start.sh
+# Requires Docker when using the default local Redis configuration.
 
 set -euo pipefail
 
 # Detect platform
 OS=$(uname -s)
 ARCH=$(uname -m)
-
-# Check docker availability
-if ! command -v docker >/dev/null 2>&1; then
-  echo "❌ Docker is required (used to run a local Redis container). Install Docker Desktop or docker engine first." >&2
-  exit 1
-fi
 
 printf "\n➡️  Detected OS: %s | Arch: %s\n" "$OS" "$ARCH"
 

--- a/morphik.toml
+++ b/morphik.toml
@@ -131,9 +131,10 @@ provider = "pgvector"
 provider = "postgres"  # "morphik" # "postgres"  # "morphik" # "postgres"  # "postgres" or "morphik" for fast implementation
 
 [redis]
-url = "redis://localhost:6379/0"  # Full Redis URL (takes precedence over host/port)
+url = "redis://localhost:6379/0"  # Full Redis URL; host/port only override this default localhost DSN
 host = "localhost"
 port = 6379
+# ssl_check_hostname = true  # Enable hostname verification for rediss:// deployments when certificates match the Redis host
 
 [worker]
 arq_max_jobs = 1  # Maximum concurrent jobs for ARQ worker

--- a/start_server.py
+++ b/start_server.py
@@ -1,49 +1,100 @@
 import argparse
+import asyncio
 import atexit
+from dataclasses import replace
 import logging
 import os
 import signal
-import socket
 import subprocess
 import sys
 import time
 
+import arq
 import requests
 import tomli
 import uvicorn
 
 from core.config import get_settings
 from core.logging_config import setup_logging
+from core.redis_settings import build_redis_settings, should_manage_local_redis
 from utils.env_loader import load_local_env
 
 # Global variable to store the worker process
-worker_process = None
+worker_process: subprocess.Popen | None = None
 
 
-def wait_for_redis(host="localhost", port=6379, timeout=20):
+def register_shutdown_handlers():
+    """Register process cleanup handlers for CLI execution."""
+    atexit.register(cleanup_processes)
+    signal.signal(signal.SIGINT, lambda sig, frame: sys.exit(0))
+    signal.signal(signal.SIGTERM, lambda sig, frame: sys.exit(0))
+
+
+async def _check_redis_connection(redis_settings):
+    redis_pool = await arq.create_pool(redis_settings)
+    try:
+        await redis_pool.ping()
+    finally:
+        await redis_pool.aclose()
+
+
+def wait_for_redis(redis_settings, timeout=20):
     """
     Wait for Redis to become available.
 
     Args:
-        host: Redis host address
-        port: Redis port number
+        redis_settings: Redis settings used by the API and ARQ worker
         timeout: Maximum time to wait in seconds
 
     Returns:
         True if Redis becomes available within the timeout, False otherwise
     """
-    logging.info(f"Waiting for Redis to be available at {host}:{port}...")
-    t0 = time.monotonic()
-    while time.monotonic() - t0 < timeout:
-        try:
-            with socket.create_connection((host, port), timeout=1):
-                logging.info("Redis is accepting connections.")
-                return True
-        except (OSError, socket.error):
-            logging.debug(f"Redis not available yet, retrying... ({int(time.monotonic() - t0)}s elapsed)")
-            time.sleep(0.3)
+    logging.info(
+        "Waiting for Redis to be available at %s:%s (db=%s, ssl=%s)...",
+        redis_settings.host,
+        redis_settings.port,
+        redis_settings.database,
+        redis_settings.ssl,
+    )
+    started_at = time.monotonic()
+    deadline = started_at + timeout
+    retry_delay = redis_settings.conn_retry_delay or 1
+    last_error = None
 
-    logging.error(f"Redis not reachable after {timeout}s")
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+
+        readiness_settings = replace(
+            redis_settings,
+            conn_timeout=max(min(redis_settings.conn_timeout, 1, remaining), 0.1),
+            conn_retries=0,
+            conn_retry_delay=retry_delay,
+        )
+
+        try:
+            asyncio.run(asyncio.wait_for(_check_redis_connection(readiness_settings), timeout=remaining))
+        except Exception as exc:
+            last_error = exc
+            sleep_for = min(retry_delay, max(deadline - time.monotonic(), 0))
+            if sleep_for <= 0:
+                break
+            time.sleep(sleep_for)
+        else:
+            logging.info("Redis connection verified.")
+            return True
+
+    elapsed = time.monotonic() - started_at
+    logging.error(
+        "Redis not reachable after %.1fs at %s:%s (db=%s, ssl=%s): %s",
+        elapsed,
+        redis_settings.host,
+        redis_settings.port,
+        redis_settings.database,
+        redis_settings.ssl,
+        last_error or "timed out",
+    )
     return False
 
 
@@ -127,8 +178,9 @@ def start_arq_worker():
 def cleanup_processes():
     """Stop the ARQ worker process on exit."""
     global worker_process
-    if worker_process and worker_process.poll() is None:  # Check if process is still running
-        logging.info(f"Stopping ARQ worker (PID: {worker_process.pid})...")
+    process = worker_process
+    if process and process.poll() is None:  # Check if process is still running
+        logging.info(f"Stopping ARQ worker (PID: {process.pid})...")
 
         # Log the worker termination
         try:
@@ -144,21 +196,21 @@ def cleanup_processes():
             logging.warning(f"Could not write worker stop message to log: {e}")
 
         # Send SIGTERM first for graceful shutdown
-        worker_process.terminate()
+        process.terminate()
         try:
             # Wait a bit for graceful shutdown
-            worker_process.wait(timeout=5)
+            process.wait(timeout=5)
             logging.info("ARQ worker stopped gracefully.")
         except subprocess.TimeoutExpired:
             logging.warning("ARQ worker did not terminate gracefully, sending SIGKILL.")
-            worker_process.kill()  # Force kill if it doesn't stop
+            process.kill()  # Force kill if it doesn't stop
             logging.info("ARQ worker killed.")
 
         # Close any open file descriptors for the process
-        if hasattr(worker_process, "stdout") and worker_process.stdout:
-            worker_process.stdout.close()
-        if hasattr(worker_process, "stderr") and worker_process.stderr:
-            worker_process.stderr.close()
+        if hasattr(process, "stdout") and process.stdout:
+            process.stdout.close()
+        if hasattr(process, "stderr") and process.stderr:
+            process.stderr.close()
 
     # Optional: Add Redis container stop logic here if desired
     # try:
@@ -166,13 +218,6 @@ def cleanup_processes():
     #     subprocess.run(["docker", "stop", "morphik-redis"], check=False, capture_output=True)
     # except Exception as e:
     #     logging.warning(f"Could not stop Redis container: {e}")
-
-
-# Register the cleanup function to be called on script exit
-atexit.register(cleanup_processes)
-# Also register for SIGINT (Ctrl+C) and SIGTERM
-signal.signal(signal.SIGINT, lambda sig, frame: sys.exit(0))
-signal.signal(signal.SIGTERM, lambda sig, frame: sys.exit(0))
 
 
 def check_ollama_running(base_url):
@@ -242,6 +287,8 @@ def get_ollama_usage_info():
 
 
 def main():
+    register_shutdown_handlers()
+
     # Parse command line arguments
     parser = argparse.ArgumentParser(description="Start the Morphik server")
     parser.add_argument(
@@ -271,12 +318,23 @@ def main():
     # Set up logging first with specified level
     setup_logging(log_level=args.log.upper())
 
-    # Check and start Redis container (unless skipped)
-    if not args.skip_redis_check:
-        check_and_start_redis()
-
     # Load environment variables from .env file if secrets aren't injected
     load_local_env(override=True)
+
+    # Load settings (this will validate all required env vars)
+    settings = get_settings()
+    redis_settings = build_redis_settings(settings)
+
+    # Check and start local Redis container only when using the default local target.
+    if not args.skip_redis_check:
+        if should_manage_local_redis(redis_settings):
+            check_and_start_redis()
+        else:
+            logging.info(
+                "Skipping local Redis container management for configured Redis target %s:%s",
+                redis_settings.host,
+                redis_settings.port,
+            )
 
     # Check if Ollama is required and running
     if not args.skip_ollama_check:
@@ -305,11 +363,8 @@ def main():
                 component_list = [config["component"] for config in ollama_configs]
                 print(f"Ollama is running and will be used for: {', '.join(component_list)}")
 
-    # Load settings (this will validate all required env vars)
-    settings = get_settings()
-
     # Wait for Redis to be available
-    if not wait_for_redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT):
+    if not wait_for_redis(redis_settings):
         logging.error("Cannot start server without Redis. Please ensure Redis is running.")
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

This PR fixes Redis startup configuration drift between the API process, `start_server.py`, and the ARQ worker. The worker already built Redis settings from `REDIS_URL`, but the API lifespan and startup readiness path could ignore credentials, database indexes, non-default ports, Unix socket targets, or TLS settings encoded in the DSN.

The change adds one shared Redis settings helper and uses it from API startup, worker startup, and CLI readiness. It keeps the legacy `REDIS_HOST`/`REDIS_PORT` override behavior for default local Redis configs while making external/authenticated Redis targets explicit and consistent.

## Changes

- Add `core.redis_settings.build_redis_settings()` to preserve `REDIS_URL` auth, DB, port, Unix socket, and TLS settings.
- Preserve the existing `REDIS_HOST`/`REDIS_PORT` fallback for default local Redis URLs, including semantically equivalent `redis://localhost:6379`.
- Reject explicitly empty `REDIS_URL` values instead of silently falling back to localhost.
- Reject authenticated remote plaintext `redis://` URLs by default, with `ALLOW_INSECURE_REMOTE_REDIS=true` as an explicit compatibility override.
- Add optional `REDIS_SSL_CHECK_HOSTNAME` / `[redis].ssl_check_hostname` support for `rediss://` deployments without changing ARQ's default hostname-check behavior.
- Use the shared helper from API lifespan Redis pool creation and ARQ worker settings.
- Make `start_server.py` verify Redis readiness through the same DSN-derived ARQ connection settings used by the API and worker.
- Keep `start_server.py` from auto-managing a local Docker Redis container for external, authenticated, TLS, or Unix socket Redis targets.
- Move CLI shutdown handler registration out of `start_server.py` import time.
- Let one-line installers reach `start_server.py` before requiring Docker, so external Redis users are not blocked by an unconditional Docker preflight; Bash now documents Docker as required for the default local Redis path.
- Add a lightweight PR CI step for the Redis settings regression tests.
- Add regression tests for DSN parsing, plaintext credential rejection, TLS hostname verification opt-in, empty URL rejection, host/port fallback, Unix socket handling, API lifespan pool settings, DSN-aware startup readiness, timeout behavior, async pool cleanup, and startup Redis management behavior.

## Why this matters

Redis is required for ingestion queueing. A managed Redis deployment commonly provides a single DSN containing credentials, database selection, non-default ports, or TLS. Before this change, Morphik could interpret Redis differently across startup paths, producing hard-to-debug API/worker mismatches.

## Tests

Commands run:

- `uv run pytest -q core/tests/unit/test_redis_settings.py` - passed, 15 tests.
- `uv run --no-project --with pytest --with pytest-asyncio --with arq --with fastapi --with pydantic-settings --with tomli --with requests --with uvicorn --with python-dotenv pytest -q core/tests/unit/test_redis_settings.py` - passed, 15 tests; this mirrors the lightweight CI regression step.
- `POSTGRES_URI=postgresql://test:test@localhost:5432/test uv run pytest -q core/tests/unit/test_week1_ingest_fixes.py core/tests/unit/test_redis_settings.py` - passed, 31 tests, with the repo's existing SWIG deprecation warnings.
- `uv run --with ruff ruff check core/config.py core/redis_settings.py core/tests/unit/test_redis_settings.py start_server.py` - passed; Ruff emitted the repo's existing warning about top-level lint settings.
- `uv run ty check core/redis_settings.py core/tests/unit/test_redis_settings.py start_server.py` - passed; `ty` emitted its standard pre-release warning.
- `uv run python -m compileall -q core/config.py core/redis_settings.py core/tests/unit/test_redis_settings.py start_server.py` - passed.
- `uv run --with pyyaml python - <<'PY' ... yaml.safe_load(Path('.github/workflows/docker-build.yml').read_text()) ... PY` - passed.
- `bash -n install_and_start.sh` - passed.
- `git diff --check` - passed.

Also checked:

- `uv run ty check core/config.py core/redis_settings.py core/tests/unit/test_redis_settings.py start_server.py` - failed on the repo's dynamic `Settings(**settings_dict)` construction in `core/config.py`; the narrower `ty` command above passes for the Redis helper, startup path, and tests.

Not run:

- Live Redis smoke test against an authenticated managed Redis instance. The regression tests assert the `RedisSettings` object passed to `arq.create_pool`.
- PowerShell syntax parse for `install_and_start.ps1` was not run locally because `pwsh` is not installed.

## Risk

Risk level: low to medium

The main compatibility guard is preserving the existing `REDIS_HOST`/`REDIS_PORT` fallback when `REDIS_URL` resolves to the default unauthenticated local Redis target. `rediss://` retains ARQ's existing hostname-check default unless `[redis].ssl_check_hostname` or `REDIS_SSL_CHECK_HOSTNAME` is explicitly set. `start_server.py` now validates Redis settings before Ollama checks so it can decide whether Redis is local or external; that can change which startup error appears first if multiple prerequisites are broken.

Rollback is straightforward because the change is isolated to Redis settings construction and startup wiring.

## Issue

Fixes #428

## Notes for maintainers

This PR intentionally does not change queue payloads, worker concurrency, Redis retry values, or Docker container lifecycle beyond deciding whether Morphik should manage the local Redis container for the effective Redis target.
