### PR TITLE
Harden ColPali ingest/query against storage failures and backpressure

### DIFF
--- a/core/vector_store/fast_multivector_store.py
+++ b/core/vector_store/fast_multivector_store.py
@@ -469,6 +469,15 @@ class FastMultiVectorStore(BaseVectorStore):
             *[self._save_chunk_to_storage(chunk, resolved_app_id) for chunk in chunks]
         )
         storage_keys = [result[0] for result in storage_results]
+        # Never persist a None content key: when external chunk storage is
+        # configured, a None key means an upload silently failed. Fail the
+        # batch (retryable) rather than committing a hole into turbopuffer.
+        if self.chunk_storage is not None and any(key is None for key in storage_keys):
+            missing = sum(1 for key in storage_keys if key is None)
+            raise RuntimeError(
+                f"{missing}/{len(storage_keys)} chunk-content uploads returned no storage key; "
+                "aborting batch to avoid storing null content"
+            )
         chunk_payload_bytes = sum(result[1] for result in storage_results if result[0])
         storage_metrics["chunk_payload_upload_s"] = time.perf_counter() - payload_start
         storage_metrics["chunk_payload_objects"] = sum(1 for key in storage_keys if key)
@@ -527,8 +536,10 @@ class FastMultiVectorStore(BaseVectorStore):
         elif isinstance(query_embedding, list):
             query_embedding = np.array(query_embedding)
 
-        # 1) Encode query embedding
-        encoded_query_embedding = fde.generate_query_encoding(query_embedding, self.fde_config).tolist()
+        # 1) Encode query embedding (off the event loop — this is CPU-bound FDE)
+        encoded_query_embedding = (
+            await asyncio.to_thread(fde.generate_query_encoding, query_embedding, self.fde_config)
+        ).tolist()
         t1 = time.perf_counter()
         logger.info(f"query_similar timing - encode_query: {(t1 - t0)*1000:.2f} ms")
 
@@ -555,22 +566,50 @@ class FastMultiVectorStore(BaseVectorStore):
         multivector_retrieval_tasks = [
             self.load_multivector_from_storage(r["multivector"][0], r["multivector"][1]) for r in result.rows
         ]
-        multivectors = await asyncio.gather(*multivector_retrieval_tasks)
+        loaded = await asyncio.gather(*multivector_retrieval_tasks, return_exceptions=True)
+        # A single missing/corrupt/lagging .npy (delete-reingest race, S3
+        # eventual consistency) must degrade one result, not 500 the whole
+        # query for every user of the app. Drop failed candidates, score the rest.
+        candidate_rows, multivectors = [], []
+        for row, mv in zip(result.rows, loaded):
+            if isinstance(mv, Exception):
+                # NB: turbopuffer Row is a pydantic model — it supports row["id"]
+                # (subscript) but NOT row.get(...). Using .get() here would raise
+                # AttributeError and 500 the whole query on exactly this degraded
+                # path, defeating the purpose of the fix.
+                logger.warning(
+                    "query_similar: skipping candidate %s — failed to load multivector: %s", row["id"], mv
+                )
+                continue
+            candidate_rows.append(row)
+            multivectors.append(mv)
+        if not multivectors:
+            logger.error(
+                "query_similar: all %d candidate multivectors failed to load; returning empty result",
+                len(result.rows),
+            )
+            return []
         t3 = time.perf_counter()
         logger.info(f"query_similar timing - load_multivectors: {(t3 - t2)*1000:.2f} ms")
 
-        # 4) Rerank using ColQwen2.5 processor
-        scores = self.processor.score_multi_vector(
-            [torch.from_numpy(query_embedding).float()], multivectors, device=self.device
+        # 4) Rerank using ColQwen2.5 processor (off the event loop — CPU-bound torch)
+        scores = (
+            await asyncio.to_thread(
+                self.processor.score_multi_vector,
+                [torch.from_numpy(query_embedding).float()],
+                multivectors,
+                device=self.device,
+            )
         )[0]
         scores, idx = torch.topk(scores, min(k, len(scores)))
         scores, top_k_indices = scores.tolist(), idx.tolist()
 
         # Log which positions from the initial store results were selected after reranking
         # This shows if top-k chunks are consistently near the top or scattered throughout candidates
-        num_candidates = len(result.rows)
+        num_candidates = len(candidate_rows)
         try:
-            selected_ids = [result.rows[i].get("id") for i in top_k_indices]
+            # Subscript, not .get() — turbopuffer Row has no .get() (see above).
+            selected_ids = [candidate_rows[i]["id"] for i in top_k_indices]
         except Exception:  # noqa: BLE001
             selected_ids = None
         logger.info(
@@ -586,7 +625,7 @@ class FastMultiVectorStore(BaseVectorStore):
         # 5) Retrieve chunk contents
         rows, storage_retrieval_tasks, parsed_metadata = [], [], []
         for i in top_k_indices:
-            row = result.rows[i]
+            row = candidate_rows[i]
             rows.append(row)
             metadata = json.loads(row["metadata"])
             parsed_metadata.append(metadata)
@@ -708,10 +747,12 @@ class FastMultiVectorStore(BaseVectorStore):
         # nothing new and was ~14% of all S3 requests on the ingest path.
         stored_size = len(npy_bytes)
 
-        # Cache on ingest so retrieval hits cache immediately
-        cache_start = time.perf_counter()
-        await self.cache.put("vectors", bucket, key, npy_bytes)
-        cache_write_time = time.perf_counter() - cache_start
+        # Do NOT cache on ingest: the vast majority of freshly-ingested pages are
+        # never queried before they age out of the LRU, so this write only evicts
+        # hot entries and adds a synchronous hop to every page's ingest. The read
+        # path (load_multivector_from_storage) already back-fills the cache on the
+        # first real miss, so retrieval latency is unaffected.
+        cache_write_time = 0.0
         return bucket, key, cache_write_time, stored_size
 
     async def save_multivector_to_storage(self, chunk: DocumentChunk) -> Tuple[str, str]:
@@ -922,8 +963,14 @@ class FastMultiVectorStore(BaseVectorStore):
             return storage_key, payload_bytes
 
         except Exception as e:
+            # Do NOT swallow: a swallowed upload failure previously returned
+            # (None, 0), which store_embeddings then wrote into turbopuffer's
+            # content column while still marking the document completed —
+            # silent, permanent per-page data loss. Re-raise so the batch fails
+            # loudly and the ingestion job is retried (S3 throttling is
+            # classified transient in the worker).
             logger.error(f"Failed to store content externally for {document_id}-{chunk_number}: {e}")
-            return None, 0
+            raise
 
     async def _save_chunk_to_storage(self, chunk: DocumentChunk, app_id: Optional[str] = None):
         return await self._store_content_externally(

--- a/core/workers/ingestion_worker.py
+++ b/core/workers/ingestion_worker.py
@@ -41,6 +41,19 @@ from core.vector_store.fast_multivector_store import FastMultiVectorStore
 from core.vector_store.multi_vector_store import MultiVectorStore
 from core.vector_store.pgvector_store import PGVectorStore
 
+# Optional infra-client exception types, imported defensively so a missing client
+# library can never break error classification. Used to recognise S3 / turbopuffer
+# backpressure (throttling, 5xx, connection blips) as transient-and-retryable.
+try:
+    from botocore.exceptions import BotoCoreError, ClientError as BotoClientError
+except Exception:  # noqa: BLE001
+    BotoCoreError = BotoClientError = None
+
+try:
+    import turbopuffer as _turbopuffer
+except Exception:  # noqa: BLE001
+    _turbopuffer = None
+
 logger = logging.getLogger(__name__)
 for noisy_logger in ("httpx", "httpcore", "aiohttp", "turbopuffer"):
     logging.getLogger(noisy_logger).setLevel(logging.WARNING)
@@ -288,13 +301,92 @@ _TRANSIENT_EXCEPTIONS = (
     ConnectionError,
 )
 
+# S3/botocore error codes that mean transient backpressure or a server-side blip.
+# Permanent errors (NoSuchBucket, AccessDenied, InvalidAccessKeyId, NoSuchKey, ...)
+# are deliberately excluded so genuine misconfiguration fails fast instead of
+# burning five retries.
+_S3_TRANSIENT_CODES = frozenset(
+    {
+        "Throttling",
+        "ThrottlingException",
+        "ThrottledException",
+        "RequestThrottled",
+        "RequestThrottledException",
+        "RequestLimitExceeded",
+        "SlowDown",
+        "RequestTimeout",
+        "RequestTimeoutException",
+        "PriorRequestNotComplete",
+        "InternalError",
+        "ServiceUnavailable",
+        "ServiceUnavailableException",
+    }
+)
+
+# botocore connection/timeout errors (subclasses of BotoCoreError, not ClientError).
+_S3_TRANSIENT_BOTOCORE_TYPES = frozenset(
+    {
+        "EndpointConnectionError",
+        "ConnectTimeoutError",
+        "ReadTimeoutError",
+        "ConnectionClosedError",
+        "ConnectionError",
+    }
+)
+
+
+def _build_turbopuffer_transient_types() -> tuple:
+    """Turbopuffer exception classes that indicate a retryable server condition."""
+    if _turbopuffer is None:
+        return ()
+    names = ("RateLimitError", "InternalServerError", "APITimeoutError", "APIConnectionError")
+    resolved = tuple(t for t in (getattr(_turbopuffer, n, None) for n in names) if isinstance(t, type))
+    return resolved
+
+
+_TURBOPUFFER_TRANSIENT_TYPES = _build_turbopuffer_transient_types()
+
+
+def _is_transient_s3_error(exc: BaseException) -> bool:
+    """True for S3 throttling / 5xx / connection blips; False for auth/not-found."""
+    if BotoClientError is not None and isinstance(exc, BotoClientError):
+        response = getattr(exc, "response", None)
+        if not isinstance(response, dict):
+            return False
+        code = response.get("Error", {}).get("Code")
+        if code in _S3_TRANSIENT_CODES:
+            return True
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode") or 0
+        return int(status) >= 500
+    if BotoCoreError is not None and isinstance(exc, BotoCoreError):
+        return type(exc).__name__ in _S3_TRANSIENT_BOTOCORE_TYPES
+    return False
+
+
+def _is_transient_turbopuffer_error(exc: BaseException) -> bool:
+    """True for turbopuffer rate-limit / 5xx / connection / timeout errors."""
+    if _TURBOPUFFER_TRANSIENT_TYPES and isinstance(exc, _TURBOPUFFER_TRANSIENT_TYPES):
+        return True
+    if _turbopuffer is not None:
+        api_status = getattr(_turbopuffer, "APIStatusError", None)
+        if isinstance(api_status, type) and isinstance(exc, api_status):
+            return int(getattr(exc, "status_code", 0) or 0) >= 500
+    return False
+
 
 def _is_transient_error(exc: BaseException) -> bool:
-    """True when the error (or its direct cause) is transient infrastructure failure."""
-    if isinstance(exc, _TRANSIENT_EXCEPTIONS):
-        return True
-    cause = exc.__cause__ or exc.__context__
-    return isinstance(cause, _TRANSIENT_EXCEPTIONS)
+    """True when the error, or anything in its cause/context chain, is a transient
+    infrastructure failure (network, embedding server, or S3/turbopuffer backpressure)."""
+    seen: set = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, _TRANSIENT_EXCEPTIONS):
+            return True
+        if _is_transient_s3_error(current) or _is_transient_turbopuffer_error(current):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 async def get_document_with_retry(ingestion_service, document_id, auth, max_retries=3, initial_delay=0.3):
@@ -687,8 +779,12 @@ async def process_ingestion_job(
             if not success:
                 raise ValueError(f"Failed to update document {document_id}")
 
-            # Refresh document object with updated data
-            doc = await ingestion_service.db.get_document(document_id, auth)
+            # No re-fetch here: the only fields this update touched (additional_metadata,
+            # system_metadata["content"], end_user_id) are never read back off `doc`
+            # downstream — only external_id/chunk_ids/folder_id are, and those are
+            # unchanged. The final completion write merges onto the locked DB row, so the
+            # persisted content survives regardless. Skipping this saves one full document
+            # read (with its projected columns) on every ingest.
             logger.debug("Updated document in database with parsed content")
 
             # 7. Split text into chunks


### PR DESCRIPTION
Three reliability fixes on the FastMultiVectorStore (turbopuffer) ingest and query paths, plus small ingest-path cleanups.

## Prevent silent content loss
`_store_content_externally` swallowed external content-upload failures and returned `(None, 0)`; `store_embeddings` then wrote a null content key into the vector store while marking the document completed — a silent, permanent per-page loss of chunk content. It now re-raises so the batch fails and the job retries, and `store_embeddings` refuses to persist a null content key.

## Classify storage backpressure as transient
The ingestion worker now treats S3 (botocore throttling / 5xx / connection blips) and turbopuffer (rate-limit / 5xx / connection / timeout) errors as retryable, walking the full exception cause/context chain. Permanent errors (access-denied, not-found, auth) still fail fast.

## Make queries resilient to a single unloadable page
`query_similar` loads the candidate multivectors with `return_exceptions=True` and drops any that fail to load (missing/corrupt/lagging object) instead of failing the entire query; it returns an empty result only when every candidate fails.

## Ingest-path cleanups
- Drop the redundant document re-fetch after the parsed-content update (the completion write merges onto the locked DB row, so persisted content is unaffected).
- Drop the ingest-time multivector cache write (the read path back-fills on first access).
- Move the CPU-bound FDE query encode and rerank scoring off the event loop with `asyncio.to_thread`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
