### PR TITLE
Keep blank PDF pages as chunks to preserve page/chunk alignment

### DIFF
--- a/core/services/ingestion_service.py
+++ b/core/services/ingestion_service.py
@@ -26,7 +26,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import arq
 import fitz  # PyMuPDF
-import numpy as np
 import pdf2image
 from fastapi import HTTPException, UploadFile
 from PIL import Image as PILImage
@@ -1400,46 +1399,20 @@ class IngestionService:
         return img_str, img_bytes
 
     @staticmethod
-    def _is_blank_image(img: PILImage.Image, tolerance: int = 2) -> bool:
-        """Return True when an image has no meaningful visual variation."""
-        grayscale = img.convert("L")
-        extrema = grayscale.getextrema()
-        if extrema is None:
-            return True
-        darkest, lightest = extrema
-        return lightest - darkest <= tolerance
+    def _placeholder_page_png() -> bytes:
+        """White stand-in for a page that fails to render.
 
-    def _is_blank_image_bytes(self, image_bytes: bytes, tolerance: int = 2) -> bool:
-        """Return True when image bytes decode to a visually blank image."""
-        if not image_bytes:
-            return True
-        try:
-            with PILImage.open(BytesIO(image_bytes)) as img:
-                return self._is_blank_image(img, tolerance=tolerance)
-        except Exception as e:
-            logger.warning("Unable to inspect rendered page image for blank-content detection: %s", e)
-            return False
-
-    @staticmethod
-    def _is_blank_pixmap(pix: "fitz.Pixmap", tolerance: int = 2) -> bool:
-        """Blank-detect on raw pixmap samples, BEFORE any image encoding.
-
-        ~100x cheaper than the old encode-PNG-then-PIL-decode round trip, and
-        blank pages skip the encode entirely. Conservative by construction:
-        it only flags pages whose every channel is flat within tolerance — a
-        subset of what the old grayscale-extrema check flagged (PNG encoding
-        is lossless, so the pixel values compared are identical).
+        Every page must produce exactly one chunk so chunk numbers stay aligned
+        with page numbers; dropping a page would shift all later chunks.
         """
-        samples = pix.samples
-        if not samples:
-            return True
-        arr = np.frombuffer(samples, dtype=np.uint8)
-        return int(arr.max()) - int(arr.min()) <= tolerance
+        buffer = BytesIO()
+        PILImage.new("RGB", (612, 792), "white").save(buffer, format="PNG")
+        return buffer.getvalue()
 
     def _render_pdf_with_pymupdf(
         self, file_content: bytes, dpi: int, include_bytes: bool = False
     ) -> List[Union[str, Tuple[str, bytes]]]:
-        """Render a PDF into base64-encoded PNG images using PyMuPDF."""
+        """Render a PDF into base64-encoded PNG images using PyMuPDF, one per page."""
         pdf_document = fitz.open("pdf", file_content)
         try:
             images: List[Union[str, Tuple[str, bytes]]] = []
@@ -1450,22 +1423,19 @@ class IngestionService:
                 try:
                     mat = fitz.Matrix(dpi / 72, dpi / 72)
                     pix = page.get_pixmap(matrix=mat)
-                    # Blank-detect on raw pixmap samples before encoding, so blank
-                    # pages skip the PNG encode entirely.
-                    if self._is_blank_pixmap(pix):
-                        logger.info("Skipping PDF page %d because it rendered as a blank image", page_index + 1)
-                        continue
                     png_bytes = pix.tobytes("png")
                 except Exception as e:
                     render_failures += 1
-                    logger.warning("Skipping PDF page %d because rendering failed: %s", page_index + 1, e)
-                    continue
+                    logger.warning(
+                        "Replacing PDF page %d with a placeholder because rendering failed: %s", page_index + 1, e
+                    )
+                    png_bytes = self._placeholder_page_png()
                 b64 = bytes_to_data_uri(png_bytes, "image/png")
                 if include_bytes:
                     images.append((b64, png_bytes))
                 else:
                     images.append(b64)
-            if not images and page_count > 0 and render_failures == page_count:
+            if page_count > 0 and render_failures == page_count:
                 raise RuntimeError("All PDF pages failed to render with PyMuPDF")
             return images
         finally:
@@ -1639,20 +1609,15 @@ class IngestionService:
                 image_payloads = []
                 for page_num, image in enumerate(images):
                     try:
-                        if self._is_blank_image(image):
-                            logger.info(
-                                "Skipping PDF page %d because it rendered as a blank image",
-                                page_num + 1,
-                            )
-                            continue
                         image_payloads.append(self.img_to_base64_with_bytes(image))
                     except Exception as page_error:
                         logger.warning(
-                            "Skipping PDF page %d because image conversion failed: %s",
+                            "Replacing PDF page %d with a placeholder because image conversion failed: %s",
                             page_num + 1,
                             page_error,
                         )
-                        continue
+                        png_bytes = self._placeholder_page_png()
+                        image_payloads.append((bytes_to_data_uri(png_bytes, "image/png"), png_bytes))
                 logger.info(f"pdf2image fallback processed {len(image_payloads)} pages")
                 return [
                     self._image_bytes_to_chunk(raw_bytes, mime_type="image/png", base64_override=image_b64)
@@ -1694,26 +1659,23 @@ class IngestionService:
                     try:
                         mat = fitz.Matrix(dpi / 72, dpi / 72)
                         pix = page.get_pixmap(matrix=mat)
-                        if self._is_blank_pixmap(pix):
-                            logger.info("Skipping PDF page %d because it rendered as a blank image", page_num + 1)
-                            del pix
-                            continue
                         png_bytes = pix.tobytes("png")
+                        # Explicitly release pixmap memory - this is the key memory optimization
+                        del pix
                     except Exception as e:
                         render_failures += 1
-                        logger.warning("Skipping PDF page %d because rendering failed: %s", page_num + 1, e)
-                        continue
+                        logger.warning(
+                            "Replacing PDF page %d with a placeholder because rendering failed: %s", page_num + 1, e
+                        )
+                        png_bytes = self._placeholder_page_png()
                     b64 = bytes_to_data_uri(png_bytes, "image/png")
 
                     # Create chunk immediately
                     chunk = self._image_bytes_to_chunk(png_bytes, mime_type="image/png", base64_override=b64)
                     all_chunks.append(chunk)
-
-                    # Explicitly release pixmap memory - this is the key memory optimization
-                    del pix
                     del png_bytes
 
-            if not all_chunks and total_pages > 0 and render_failures == total_pages:
+            if total_pages > 0 and render_failures == total_pages:
                 raise RuntimeError("All PDF pages failed to render with PyMuPDF")
 
             logger.info(f"PyMuPDF processed {total_pages} pages in batched mode")
@@ -1830,28 +1792,22 @@ class IngestionService:
                             pix = page.get_pixmap(matrix=mat)
                             img_data = pix.tobytes("png")
                             img = PILImage.open(BytesIO(img_data))
-                            if self._is_blank_image(img):
-                                logger.info(
-                                    "Skipping %s page %d because it rendered as a blank image",
-                                    doc_type,
-                                    page_num + 1,
-                                )
-                                continue
                             img_str, img_bytes = self.img_to_base64_with_bytes(img)
-                            images_payload.append((img_str, img_bytes))
                         except Exception as page_error:
                             render_failures += 1
                             logger.warning(
-                                "Skipping %s page %d because rendering failed: %s",
+                                "Replacing %s page %d with a placeholder because rendering failed: %s",
                                 doc_type,
                                 page_num + 1,
                                 page_error,
                             )
-                            continue
+                            img_bytes = self._placeholder_page_png()
+                            img_str = bytes_to_data_uri(img_bytes, "image/png")
+                        images_payload.append((img_str, img_bytes))
                 finally:
                     pdf_document.close()
 
-                if not images_payload and total_pages > 0 and render_failures == total_pages:
+                if total_pages > 0 and render_failures == total_pages:
                     raise RuntimeError(f"All {doc_type} pages failed to render with PyMuPDF")
 
                 logger.info(f"{doc_type} successfully processed {len(images_payload)} pages as images")
@@ -1867,22 +1823,16 @@ class IngestionService:
                     images_payload = []
                     for page_num, image in enumerate(images):
                         try:
-                            if self._is_blank_image(image):
-                                logger.info(
-                                    "Skipping %s page %d because it rendered as a blank image",
-                                    doc_type,
-                                    page_num + 1,
-                                )
-                                continue
                             images_payload.append(self.img_to_base64_with_bytes(image))
                         except Exception as page_error:
                             logger.warning(
-                                "Skipping %s page %d because image conversion failed: %s",
+                                "Replacing %s page %d with a placeholder because image conversion failed: %s",
                                 doc_type,
                                 page_num + 1,
                                 page_error,
                             )
-                            continue
+                            png_bytes = self._placeholder_page_png()
+                            images_payload.append((bytes_to_data_uri(png_bytes, "image/png"), png_bytes))
 
                     logger.info(f"{doc_type} processed {len(images_payload)} pages with pdf2image")
                     return [

--- a/core/tests/unit/test_ingestion_colpali_rendering.py
+++ b/core/tests/unit/test_ingestion_colpali_rendering.py
@@ -2,6 +2,7 @@ import subprocess
 from io import BytesIO
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from core.services import ingestion_service as ingestion_module
@@ -11,11 +12,6 @@ from core.services.ingestion_service import IngestionService
 class FakePixmap:
     def __init__(self, image_bytes: bytes):
         self._image_bytes = image_bytes
-        if image_bytes:
-            with Image.open(BytesIO(image_bytes)) as img:
-                self.samples = img.convert("RGB").tobytes()
-        else:
-            self.samples = b""
 
     def tobytes(self, format: str) -> bytes:
         assert format == "png"
@@ -66,7 +62,7 @@ def _non_blank_png_bytes() -> bytes:
     return output.getvalue()
 
 
-def test_render_pdf_with_pymupdf_skips_blank_and_failed_pages(monkeypatch):
+def test_render_pdf_with_pymupdf_keeps_every_page(monkeypatch):
     service = IngestionService(None, None, None, None, None)
     fake_document = FakeDocument(
         [
@@ -81,12 +77,32 @@ def test_render_pdf_with_pymupdf_skips_blank_and_failed_pages(monkeypatch):
 
     rendered_pages = service._render_pdf_with_pymupdf(b"%PDF", dpi=72, include_bytes=True)
 
-    assert len(rendered_pages) == 2
+    # Blank and failed pages must still produce one image each so that the
+    # position in the list always matches the page number in the source PDF.
+    assert len(rendered_pages) == 4
+    assert rendered_pages[1][1] == IngestionService._placeholder_page_png()
+    assert rendered_pages[2][1] == _png_bytes((255, 255, 255))
     assert all(image_b64.startswith("data:image/png;base64,") for image_b64, _ in rendered_pages)
     assert fake_document.closed is True
 
 
-def test_pdf_pdf2image_fallback_skips_blank_and_failed_pages(monkeypatch):
+def test_render_pdf_with_pymupdf_raises_when_all_pages_fail(monkeypatch):
+    service = IngestionService(None, None, None, None, None)
+    fake_document = FakeDocument(
+        [
+            FakePage(error=RuntimeError("bad page")),
+            FakePage(error=RuntimeError("bad page")),
+        ]
+    )
+
+    monkeypatch.setattr(ingestion_module.fitz, "open", lambda *args, **kwargs: fake_document)
+
+    with pytest.raises(RuntimeError):
+        service._render_pdf_with_pymupdf(b"%PDF", dpi=72, include_bytes=True)
+    assert fake_document.closed is True
+
+
+def test_pdf_pdf2image_fallback_keeps_every_page(monkeypatch):
     service = IngestionService(None, None, None, None, None)
     good_page = Image.open(BytesIO(_non_blank_png_bytes()))
     blank_page = Image.open(BytesIO(_png_bytes((255, 255, 255))))
@@ -116,12 +132,12 @@ def test_pdf_pdf2image_fallback_skips_blank_and_failed_pages(monkeypatch):
 
     chunks = service._process_pdf_for_colpali(b"%PDF")
 
-    assert len(chunks) == 2
+    assert len(chunks) == 4
     assert all(chunk.metadata["is_image"] is True for chunk in chunks)
     assert all(chunk.content.startswith("data:image/png;base64,") for chunk in chunks)
 
 
-def test_office_conversion_skips_blank_and_failed_pages(monkeypatch):
+def test_office_conversion_keeps_every_page(monkeypatch):
     service = IngestionService(None, None, None, None, None)
     fake_document = FakeDocument(
         [
@@ -146,7 +162,7 @@ def test_office_conversion_skips_blank_and_failed_pages(monkeypatch):
 
     chunks = service._convert_office_to_images(b"pptx-bytes", ".pptx", "PowerPoint presentation", [])
 
-    assert len(chunks) == 2
+    assert len(chunks) == 4
     assert all(chunk.metadata["is_image"] is True for chunk in chunks)
     assert all(chunk.content.startswith("data:image/png;base64,") for chunk in chunks)
     assert fake_document.closed is True

--- a/core/tests/unit/test_week1_ingest_fixes.py
+++ b/core/tests/unit/test_week1_ingest_fixes.py
@@ -3,7 +3,6 @@
 Covers:
 - embed-client transient retry + EmbeddingUnavailableError semantics
 - worker transient-error classification
-- blank-page detection on raw pixmap samples (pre-encode)
 - _image_bytes omission in ColPali API mode
 - S3 bucket-check caching, direct byte upload, and HEAD elimination
 - base64 size arithmetic replacing HEAD-after-PUT
@@ -53,19 +52,6 @@ def _make_model(transport: httpx.MockTransport) -> ColpaliApiEmbeddingModel:
     model._latest_ingest_metrics = {}
     model._http_client = httpx.AsyncClient(transport=transport)
     return model
-
-
-def _render_pixmap(color=(255, 255, 255), dot=False) -> fitz.Pixmap:
-    doc = fitz.open()
-    page = doc.new_page(width=100, height=100)
-    if color != (255, 255, 255):
-        rgb = tuple(c / 255 for c in color)
-        page.draw_rect(fitz.Rect(0, 0, 100, 100), color=rgb, fill=rgb)
-    if dot:
-        page.draw_rect(fitz.Rect(40, 40, 60, 60), color=(0, 0, 0), fill=(0, 0, 0))
-    pix = page.get_pixmap()
-    doc.close()
-    return pix
 
 
 # ---------------------------------------------------------------------------
@@ -183,19 +169,8 @@ def test_transient_classification():
 
 
 # ---------------------------------------------------------------------------
-# render path: blank check + encoding
+# render path: encoding
 # ---------------------------------------------------------------------------
-
-
-def test_blank_pixmap_detection_matches_old_behavior():
-    svc = object.__new__(IngestionService)
-    blank = _render_pixmap()
-    content = _render_pixmap(dot=True)
-    assert svc._is_blank_pixmap(blank) is True
-    assert svc._is_blank_pixmap(content) is False
-    # agreement with the legacy bytes-based check on the encoded PNGs
-    assert svc._is_blank_image_bytes(blank.tobytes("png")) is True
-    assert svc._is_blank_image_bytes(content.tobytes("png")) is False
 
 
 def test_image_bytes_omitted_in_api_mode(monkeypatch):
@@ -299,14 +274,14 @@ def _small_pdf_with_blank() -> bytes:
     return doc.tobytes()
 
 
-def test_render_pdf_returns_png_pairs_and_skips_blank():
+def test_render_pdf_returns_png_pairs_and_keeps_blank():
     svc = object.__new__(IngestionService)
     pages = svc._render_pdf_with_pymupdf(_small_pdf_with_blank(), dpi=72, include_bytes=True)
-    assert len(pages) == 1  # blank page skipped
-    b64, raw = pages[0]
-    assert b64.startswith("data:image/png;base64,")
-    assert raw.startswith(b"\x89PNG")
-    assert base64.b64decode(b64.split(",", 1)[1]) == raw
+    assert len(pages) == 2, "blank pages must stay so chunk numbers keep matching page numbers"
+    for b64, raw in pages:
+        assert b64.startswith("data:image/png;base64,")
+        assert raw.startswith(b"\x89PNG")
+        assert base64.b64decode(b64.split(",", 1)[1]) == raw
 
 
 # ---------------------------------------------------------------------------
@@ -365,19 +340,17 @@ async def test_retry_after_is_capped(monkeypatch):
     assert max(sleeps) <= 30.0, f"Retry-After must be capped at 30s, slept {max(sleeps)}"
 
 
-def test_render_page_error_skips_page_not_document(monkeypatch):
+def test_render_page_error_becomes_placeholder_not_abort(monkeypatch):
     svc = object.__new__(IngestionService)
 
     calls = {"n": 0}
-    real_blank = IngestionService._is_blank_pixmap  # staticmethod -> plain function
+    real_matrix = fitz.Matrix
 
-    def flaky_blank(pix, tolerance=2):
+    def flaky_matrix(*args, **kwargs):
         calls["n"] += 1
         if calls["n"] == 1:
             raise RuntimeError("render step blew up on page 1")
-        return real_blank(pix, tolerance)
-
-    monkeypatch.setattr(svc, "_is_blank_pixmap", flaky_blank)
+        return real_matrix(*args, **kwargs)
 
     doc = fitz.open()
     for _ in range(3):
@@ -385,5 +358,9 @@ def test_render_page_error_skips_page_not_document(monkeypatch):
         page.draw_rect(fitz.Rect(20, 20, 80, 80), color=(0, 0, 0), fill=(0.3, 0.3, 0.3))
     pdf = doc.tobytes()
 
+    monkeypatch.setattr(ingestion_module.fitz, "Matrix", flaky_matrix)
+
     pages = svc._render_pdf_with_pymupdf(pdf, dpi=72, include_bytes=True)
-    assert len(pages) == 2, "one bad page must not abort the document"
+    assert len(pages) == 3, "one bad page must not abort the document or shift page numbering"
+    assert pages[0][1] == IngestionService._placeholder_page_png()
+    assert pages[1][1] != pages[0][1]


### PR DESCRIPTION
## Problem

Since #399, pages that render as visually blank are dropped during ColPali PDF/office rendering. That compacts the chunk list, so chunk numbers no longer match source page numbers for any document containing blank pages — anything that maps a chunk back to its page (viewers, citations) points at the wrong page.

## Change

- Render every page: blank pages become normal chunks again, restoring the chunk-N == page-N invariant.
- A page that fails to render now yields a white placeholder chunk instead of being silently dropped (a dropped page shifts numbering the same way a blank one did).
- Documents where every page fails to render still raise, and the pdf2image / text-extraction fallbacks are unchanged.
- Removed the now-unused blank-detection helpers.

## Tests

- Updated rendering tests: all pages kept, placeholders substituted at the right positions, all-pages-failed still raises.
- Verified end-to-end that a PDF with interleaved blank pages produces one chunk per page, in page order, through both the normal and high-density batched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)