### PR TITLE
Harden on-prem lifecycle and document iQor integration gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ JWT_SECRET_KEY="your-super-secret-key-change-in-production"
 SESSION_SECRET_KEY="your-session-secret-key-change-in-production"
 POSTGRES_URI="postgresql+asyncpg://morphik:morphik@localhost:5432/morphik"
 
+# Set once before the first Docker start to keep volume names stable across directory moves.
+# Do not change this on an existing deployment without migrating its named volumes.
+# COMPOSE_PROJECT_NAME=morphik
+
 # LLM Provider API Keys (set the ones you use)
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
@@ -18,3 +22,4 @@ TURBOPUFFER_API_KEY=
 SENTRY_DSN=
 LOCAL_URI_PASSWORD=
 LITELLM_DUMMY_API_KEY=
+LITELLM_LOCAL_MODEL_COST_MAP=True

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 .eggs/
 *.egg
 *.pytest_cache/
+iqor-retrieval-response*.json
 
 core/tests/output
 core/tests/assets

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -31,16 +31,25 @@ The initial setup may take 5-10 minutes depending on your internet speed, as it 
 
 3. For subsequent runs:
 ```bash
-docker compose up    # Start all services
-docker compose down  # Stop all services
+./start-morphik.sh
+./stop-morphik.sh
 ```
+
+Both commands are idempotent. The stop script removes containers and the Compose network, including services in
+optional profiles, but preserves the named volumes that hold PostgreSQL, Redis, and model data.
 
 4. To completely reset (will delete all data and models):
 ```bash
 docker compose down -v
 ```
 
-> **Note:** If you enabled the optional UI profile (or any other compose profile), make sure to include `--profile ui` when stopping services (`docker compose --profile ui down --volumes --remove-orphans`). The hosted installer generates a `stop-morphik` script that does this for you automatically.
+This command is destructive. Do not use it for a routine stop:
+
+```bash
+docker compose -f docker-compose.run.yml --profile "*" down --volumes --remove-orphans
+```
+
+It removes PostgreSQL and every other named volume. Back up the database and `./storage` before an intentional reset.
 
 ## Configuration
 
@@ -113,7 +122,7 @@ services:
 
 ## Storage and Data
 
-- Database data: Stored in the `postgres_data` Docker volume
+- Database data: Stored in the `postgres_data` Docker volume outside the PostgreSQL container
 - AI Models: Stored in the `ollama_data` Docker volume
 - Documents: Stored in `./storage` directory (mounted to container)
 - Logs: Available in `./logs` directory

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,6 +1,7 @@
-# Docker Setup Guide for Morphik Core
+# Docker setup guide for Morphik Core
 
-Morphik Core provides a streamlined Docker-based setup that includes all necessary components: the core API, PostgreSQL with pgvector, and Ollama for AI models.
+This guide uses the production Compose deployment in `docker-compose.run.yml`. It runs the published Morphik Core
+image with PostgreSQL and Redis. Ollama and the admin UI are optional profiles.
 
 ## Prerequisites
 
@@ -8,28 +9,26 @@ Morphik Core provides a streamlined Docker-based setup that includes all necessa
 - At least 10GB of free disk space (for models and data)
 - 8GB+ RAM recommended
 
-## Quick Start
+## Quick start
 
 1. Clone the repository and navigate to the project directory:
+
 ```bash
 git clone https://github.com/morphik-org/morphik-core.git
 cd morphik-core
 ```
 
-2. First-time setup:
+2. Run the production installer:
+
 ```bash
-docker compose up --build
+./install_docker.sh
 ```
 
-This command will:
-- Build all required containers
-- Download necessary AI models (nomic-embed-text and llama3.2)
-- Initialize the PostgreSQL database with pgvector
-- Start all services
-
-The initial setup may take 5-10 minutes depending on your internet speed, as it needs to download the AI models.
+The installer pulls the published image, creates `.env`, writes the Docker configuration, asks which model provider to
+use, and starts `docker-compose.run.yml`.
 
 3. For subsequent runs:
+
 ```bash
 ./start-morphik.sh
 ./stop-morphik.sh
@@ -38,12 +37,7 @@ The initial setup may take 5-10 minutes depending on your internet speed, as it 
 Both commands are idempotent. The stop script removes containers and the Compose network, including services in
 optional profiles, but preserves the named volumes that hold PostgreSQL, Redis, and model data.
 
-4. To completely reset (will delete all data and models):
-```bash
-docker compose down -v
-```
-
-This command is destructive. Do not use it for a routine stop:
+4. To completely reset all Compose-managed data, run this destructive command:
 
 ```bash
 docker compose -f docker-compose.run.yml --profile "*" down --volumes --remove-orphans
@@ -53,32 +47,36 @@ It removes PostgreSQL and every other named volume. Back up the database and `./
 
 ## Configuration
 
-### 1. Default Setup
+### 1. Default setup
 
-The default configuration works out of the box and includes:
+The installed stack includes:
+
 - PostgreSQL with pgvector for document storage
-- Ollama for AI models (embeddings and completions)
+- Redis for ingestion jobs
 - Local file storage
-- Basic authentication
+- Configurable local or external model providers
+- Token authentication or explicit local-only bypass mode
 
-### 2. Configuration File (morphik.toml)
+### 2. Configuration file
 
-The default `morphik.toml` is configured for Docker and includes:
+Edit the generated `morphik.toml`. For example, an Ollama container on the same Compose network uses:
 
 ```toml
 [api]
-host = "0.0.0.0"  # Important: Use 0.0.0.0 for Docker
+host = "0.0.0.0"
 port = 8000
 
+[registered_models]
+ollama_chat = { model_name = "ollama_chat/llama3.2", api_base = "http://ollama:11434" }
+ollama_embedding = { model_name = "ollama/nomic-embed-text", api_base = "http://ollama:11434" }
+
 [completion]
-provider = "ollama"
-model_name = "llama3.2"
-base_url = "http://ollama:11434"  # Use Docker service name
+model = "ollama_chat"
 
 [embedding]
-provider = "ollama"
-model_name = "nomic-embed-text"
-base_url = "http://ollama:11434"  # Use Docker service name
+model = "ollama_embedding"
+dimensions = 768
+similarity_metric = "cosine"
 
 [database]
 provider = "postgres"
@@ -89,38 +87,39 @@ provider = "pgvector"
 [storage]
 provider = "local"
 storage_path = "/app/storage"
+
+[morphik]
+mode = "self_hosted"
+enable_colpali = false
+colpali_mode = "off"
 ```
 
-### 3. Environment Variables
+Set `COMPOSE_PROFILES=ollama` in `.env` before starting this example. Pull the required models into Ollama before using
+the API.
 
-Create a `.env` file to customize these settings:
+### 3. Environment variables
+
+The installer creates `.env`. Review these values before exposing the service:
 
 ```bash
 JWT_SECRET_KEY=your-secure-key-here  # Important: Change in production
 OPENAI_API_KEY=sk-...                # Only if using OpenAI
-HOST=0.0.0.0                         # Leave as is for Docker
-PORT=8000                            # Change if needed
+TELEMETRY=false                      # Recommended for a no-egress deployment
+COMPOSE_PROJECT_NAME=morphik         # Set once before the first start
 ```
 
-### 4. Custom Configuration
+### 4. Custom configuration
 
-To use your own configuration:
-1. Create a custom `morphik.toml`
-2. Mount it in `docker-compose.yml`:
-```yaml
-services:
-  morphik:
-    volumes:
-      - ./my-custom-morphik.toml:/app/morphik.toml
-```
+`docker-compose.run.yml` mounts `./morphik.toml` read-only into both the API and worker containers. Edit that file and
+run `./start-morphik.sh` again to apply changes.
 
-## Accessing Services
+## Accessing services
 
 - Morphik API: http://localhost:8000
 - API Documentation: http://localhost:8000/docs
 - Health Check: http://localhost:8000/health
 
-## Storage and Data
+## Storage and data
 
 - Database data: Stored in the `postgres_data` Docker volume outside the PostgreSQL container
 - AI Models: Stored in the `ollama_data` Docker volume
@@ -129,47 +128,54 @@ services:
 
 ## Troubleshooting
 
-1. **Service Won't Start**
+1. **Service will not start**
+
    ```bash
    # View all logs
-   docker compose logs
+   docker compose -f docker-compose.run.yml --profile "*" logs
 
    # View specific service logs
-   docker compose logs morphik
-   docker compose logs postgres
-   docker compose logs ollama
+   docker compose -f docker-compose.run.yml logs morphik
+   docker compose -f docker-compose.run.yml logs postgres
+   docker compose -f docker-compose.run.yml --profile ollama logs ollama
    ```
 
-2. **Database Issues**
-   - Check PostgreSQL is healthy: `docker compose ps`
-   - Verify database connection: `docker compose exec postgres psql -U morphik -d morphik`
+2. **Database issues**
 
-3. **Model Download Issues**
-   - Check Ollama logs: `docker compose logs ollama`
+   - Check PostgreSQL health: `docker compose -f docker-compose.run.yml ps`
+   - Verify the database: `docker compose -f docker-compose.run.yml exec postgres psql -U morphik -d morphik`
+
+3. **Model download issues**
+
+   - Check Ollama logs: `docker compose -f docker-compose.run.yml --profile ollama logs ollama`
    - Ensure enough disk space for models
-   - Try restarting Ollama: `docker compose restart ollama`
+   - Restart Ollama: `docker compose -f docker-compose.run.yml --profile ollama restart ollama`
 
-4. **Performance Issues**
+4. **Performance issues**
+
    - Monitor resources: `docker stats`
    - Ensure sufficient RAM (8GB+ recommended)
    - Check disk space: `df -h`
 
-## Production Deployment
+## Production deployment
 
 For production environments:
 
-1. **Security**:
+1. **Security**
+
    - Change the default `JWT_SECRET_KEY`
    - Use proper network security groups
    - Enable HTTPS (recommended: use a reverse proxy)
    - Regularly update containers and dependencies
 
-2. **Persistence**:
+2. **Persistence**
+
    - Use named volumes for all data
    - Set up regular backups of PostgreSQL
    - Back up the storage directory
 
-3. **Monitoring**:
+3. **Monitoring**
+
    - Set up container monitoring
    - Configure proper logging
    - Use health checks
@@ -177,9 +183,10 @@ For production environments:
 ## Support
 
 For issues and feature requests:
+
 - GitHub Issues: [https://github.com/morphik-org/morphik-core/issues](https://github.com/morphik-org/morphik-core/issues)
 - Documentation: [https://docs.morphik.ai](https://docs.morphik.ai)
 
-## Repository Information
+## Repository information
 
 - License: MIT

--- a/core/routes/logs.py
+++ b/core/routes/logs.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from core.auth_utils import verify_token
+from core.config import get_settings
 from core.models.auth import AuthContext
 from core.services.telemetry_events import TelemetryEventReader
 
@@ -117,7 +118,7 @@ async def get_logs(
             status=status_filter,
             since=since,
         )
-    else:
+    elif get_settings().TELEMETRY_ENABLED:
         events = await _query_proxy(
             app_id=auth.app_id,
             since=since,
@@ -125,6 +126,9 @@ async def get_logs(
             operation_type=op_type,
             status=status_filter,
         )
+    else:
+        logger.info("Historical log proxy disabled because telemetry is disabled")
+        events = []
 
     return [
         LogResponse(

--- a/core/services/document_service.py
+++ b/core/services/document_service.py
@@ -40,6 +40,11 @@ SUMMARY_FILE_EXTENSION = ".md"
 SUMMARY_CONTENT_TYPE = "text/markdown"
 
 
+def _filter_chunks_by_min_score(chunks: List[DocumentChunk], min_score: float) -> List[DocumentChunk]:
+    """Return chunks whose final relevance score meets the request threshold."""
+    return [chunk for chunk in chunks if chunk.score >= min_score]
+
+
 class DocumentService:
     """Service for document retrieval and query operations.
 
@@ -486,6 +491,12 @@ class DocumentService:
                 )
         else:
             phase_times["multivector_chunk_combination"] = phase_times.get("multivector_chunk_combination", 0.0)
+
+        # Apply the threshold after vector scoring and optional reranking, but before
+        # adding zero-score padding chunks. RetrieveRequest has exposed min_score for
+        # years; keeping the filtering here makes the request field effective for all
+        # retrieval backends.
+        chunks = _filter_chunks_by_min_score(chunks, min_score)
 
         # Apply padding if requested and using colpali
         if padding > 0 and using_multivector:

--- a/core/tests/integration/test_docker_postgres_persistence.py
+++ b/core/tests/integration/test_docker_postgres_persistence.py
@@ -1,0 +1,27 @@
+"""Docker-level persistence test for the production Compose deployment."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEST_SCRIPT = REPO_ROOT / "scripts" / "test_postgres_persistence.sh"
+
+
+@pytest.mark.integration
+def test_document_survives_postgres_container_recreation():
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is not installed")
+
+    daemon = subprocess.run(
+        ["docker", "info"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if daemon.returncode != 0:
+        pytest.skip("Docker daemon is not running")
+
+    subprocess.run([str(TEST_SCRIPT)], cwd=REPO_ROOT, check=True, timeout=300)

--- a/core/tests/unit/test_docker_lifecycle.py
+++ b/core/tests/unit/test_docker_lifecycle.py
@@ -45,6 +45,15 @@ def test_normal_stop_preserves_volumes_and_stops_all_profiles():
     assert "Persistent named volumes were preserved" in windows_installer
 
 
+def test_persistence_test_uses_a_non_overridable_unique_project():
+    script = _read("scripts/test_postgres_persistence.sh")
+
+    assert 'TEST_PROJECT="morphik-persistence-test-$$-${RANDOM}"' in script
+    assert "MORPHIK_PERSISTENCE_TEST_PROJECT" not in script
+    assert "Refusing to reuse existing Docker resources" in script
+    assert "\ncleanup\n" not in script
+
+
 def test_start_is_repeatable_without_rewriting_compose():
     checked_in_start = _read("start-morphik.sh")
     unix_installer = _read("install_docker.sh")

--- a/core/tests/unit/test_docker_lifecycle.py
+++ b/core/tests/unit/test_docker_lifecycle.py
@@ -1,12 +1,22 @@
 """Static guards for the installer-generated production lifecycle scripts."""
 
+import os
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _read(relative_path: str) -> str:
     return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _installer_start_script() -> str:
+    installer = _read("install_docker.sh")
+    marker = "cat > start-morphik.sh << 'EOF'\n"
+    return installer.split(marker, 1)[1].split("\nEOF\nchmod +x start-morphik.sh", 1)[0]
 
 
 def test_production_compose_persists_postgres_without_fixed_container_names():
@@ -43,3 +53,60 @@ def test_start_is_repeatable_without_rewriting_compose():
     assert "up -d --remove-orphans" in checked_in_start
     assert "export MORPHIK_API_PORT=" in unix_installer
     assert "`$env:MORPHIK_API_PORT = `$desired" in windows_installer
+
+
+def test_docker_guide_uses_the_production_compose_path_consistently():
+    guide = _read("DOCKER.md")
+
+    assert "./install_docker.sh" in guide
+    assert "docker compose up --build" not in guide
+    assert "docker-compose.yml" not in guide
+    assert "docker-compose.run.yml" in guide
+
+
+@pytest.mark.parametrize(
+    "script_text",
+    [_read("start-morphik.sh"), _installer_start_script()],
+    ids=["checked-in", "installer-generated"],
+)
+def test_start_defaults_to_latest_when_env_omits_version(tmp_path, script_text):
+    deployment = tmp_path / "deployment"
+    deployment.mkdir()
+    script = deployment / "start-morphik.sh"
+    script.write_text(script_text, encoding="utf-8")
+    script.chmod(0o755)
+    (deployment / ".env").write_text("JWT_SECRET_KEY=test-only\n", encoding="utf-8")
+    (deployment / "morphik.toml").write_text("[api]\nport = 8123\n", encoding="utf-8")
+    (deployment / "docker-compose.run.yml").write_text("services: {}\n", encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        '#!/usr/bin/env bash\nprintf "%s|%s\\n" "$MORPHIK_VERSION" "$MORPHIK_API_PORT" > "$FAKE_DOCKER_OUTPUT"\n',
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+    docker_output = tmp_path / "docker-output"
+
+    env = os.environ.copy()
+    env.pop("MORPHIK_VERSION", None)
+    env.pop("COMPOSE_PROFILES", None)
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "FAKE_DOCKER_OUTPUT": str(docker_output),
+        }
+    )
+
+    completed = subprocess.run(
+        [str(script)],
+        cwd=deployment,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "Using Morphik version: latest" in completed.stdout
+    assert docker_output.read_text(encoding="utf-8").strip() == "latest|8123"

--- a/core/tests/unit/test_docker_lifecycle.py
+++ b/core/tests/unit/test_docker_lifecycle.py
@@ -26,6 +26,8 @@ def test_production_compose_persists_postgres_without_fixed_container_names():
     assert "container_name:" not in compose
     assert '"5432:5432"' not in compose
     assert "${MORPHIK_API_PORT:-8000}:${MORPHIK_API_PORT:-8000}" in compose
+    assert '"${MORPHIK_ENV_FILE:-.env}"' in compose
+    assert "required:" not in compose
     assert "# COMPOSE_PROJECT_NAME=morphik" in _read(".env.example")
     assert "LITELLM_LOCAL_MODEL_COST_MAP=${LITELLM_LOCAL_MODEL_COST_MAP:-True}" in compose
 

--- a/core/tests/unit/test_docker_lifecycle.py
+++ b/core/tests/unit/test_docker_lifecycle.py
@@ -1,0 +1,45 @@
+"""Static guards for the installer-generated production lifecycle scripts."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_production_compose_persists_postgres_without_fixed_container_names():
+    compose = _read("docker-compose.run.yml")
+
+    assert "postgres_data:/var/lib/postgresql/data" in compose
+    assert "container_name:" not in compose
+    assert '"5432:5432"' not in compose
+    assert "${MORPHIK_API_PORT:-8000}:${MORPHIK_API_PORT:-8000}" in compose
+    assert "# COMPOSE_PROJECT_NAME=morphik" in _read(".env.example")
+    assert "LITELLM_LOCAL_MODEL_COST_MAP=${LITELLM_LOCAL_MODEL_COST_MAP:-True}" in compose
+
+
+def test_normal_stop_preserves_volumes_and_stops_all_profiles():
+    checked_in_stop = _read("stop-morphik.sh")
+    unix_installer = _read("install_docker.sh")
+    windows_installer = _read("install_docker.ps1")
+
+    assert '--profile "*" down --remove-orphans' in checked_in_stop
+    assert "down --volumes" not in checked_in_stop
+    assert "down --volumes" not in unix_installer
+    assert "'down','--volumes'" not in windows_installer
+    assert "Persistent named volumes were preserved" in unix_installer
+    assert "Persistent named volumes were preserved" in windows_installer
+
+
+def test_start_is_repeatable_without_rewriting_compose():
+    checked_in_start = _read("start-morphik.sh")
+    unix_installer = _read("install_docker.sh")
+    windows_installer = _read("install_docker.ps1")
+
+    assert "export MORPHIK_API_PORT=" in checked_in_start
+    assert "docker-compose.run.yml.tmp" not in checked_in_start
+    assert "up -d --remove-orphans" in checked_in_start
+    assert "export MORPHIK_API_PORT=" in unix_installer
+    assert "`$env:MORPHIK_API_PORT = `$desired" in windows_installer

--- a/core/tests/unit/test_docker_lifecycle.py
+++ b/core/tests/unit/test_docker_lifecycle.py
@@ -52,6 +52,10 @@ def test_persistence_test_uses_a_non_overridable_unique_project():
     assert "MORPHIK_PERSISTENCE_TEST_PROJECT" not in script
     assert "Refusing to reuse existing Docker resources" in script
     assert "\ncleanup\n" not in script
+    assert "trap cleanup EXIT" in script
+    assert "trap 'exit 130' INT" in script
+    assert "trap 'exit 143' TERM" in script
+    assert "trap cleanup EXIT INT TERM" not in script
 
 
 def test_start_is_repeatable_without_rewriting_compose():

--- a/core/tests/unit/test_ingestion_service_metadata_update.py
+++ b/core/tests/unit/test_ingestion_service_metadata_update.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -65,6 +65,15 @@ class FakeStoreFailureDatabase(FakeDatabase):
             }
         )
         return False
+
+
+class FakeRedis:
+    def __init__(self):
+        self.calls = []
+
+    async def enqueue_job(self, function_name, **payload):
+        self.calls.append({"function_name": function_name, "payload": payload})
+        return SimpleNamespace(job_id=payload["_job_id"])
 
 
 def _auth() -> AuthContext:
@@ -234,3 +243,55 @@ async def test_queued_metadata_only_update_allows_unchanged_managed_metadata_fie
     assert updated is doc
     assert doc.metadata["custom"] == "queued"
     assert len(db.update_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_queued_text_update_preserves_identity_metadata_and_queues_reindex():
+    doc = _document()
+    original_metadata = dict(doc.metadata)
+    service, db = _service(doc)
+    redis = FakeRedis()
+
+    async def noop_limit_check(auth, content_length, document_id):
+        return None
+
+    async def fake_upload(*, content_bytes, filename, content_type):
+        assert content_bytes == b"corrected QA backlog text"
+        return "app-1", "ingest_uploads/replacement/report.txt", "report.txt"
+
+    async def noop_record(*args, **kwargs):
+        return None
+
+    async def no_stored_size(*args, **kwargs):
+        return None
+
+    service._verify_ingest_and_storage_limits = noop_limit_check
+    service._upload_content_bytes = fake_upload
+    service._record_storage_usage = noop_record
+    service._get_storage_object_size = no_stored_size
+
+    updated = await service.queue_document_update(
+        document_id="doc-1",
+        auth=_auth(),
+        redis=redis,
+        content="corrected QA backlog text",
+        use_colpali=False,
+    )
+
+    assert updated is doc
+    assert updated.external_id == "doc-1"
+    assert updated.metadata == original_metadata
+    assert updated.system_metadata["status"] == "processing"
+    assert updated.storage_info["key"] == "ingest_uploads/replacement/report.txt"
+
+    persisted = db.update_calls[-1]
+    assert persisted["document_id"] == "doc-1"
+    assert persisted["updates"]["metadata"] == original_metadata
+    assert persisted["updates"]["system_metadata"]["status"] == "processing"
+
+    assert len(redis.calls) == 1
+    queued = redis.calls[0]
+    assert queued["function_name"] == "process_ingestion_job"
+    assert queued["payload"]["document_id"] == "doc-1"
+    assert queued["payload"]["file_key"] == "ingest_uploads/replacement/report.txt"
+    assert queued["payload"]["_job_id"] == "ingest:doc-1"

--- a/core/tests/unit/test_iqor_retrieval_script.py
+++ b/core/tests/unit/test_iqor_retrieval_script.py
@@ -32,7 +32,8 @@ def _result(work_item_id: int, score: float, chunk_number: int = 0) -> dict:
     }
 
 
-def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path):
+@pytest.mark.parametrize("explicit_response_path", [True, False], ids=["explicit-path", "temporary-path"])
+def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path, explicit_response_path):
     if shutil.which("curl") is None or shutil.which("jq") is None:
         pytest.skip("curl and jq are required")
 
@@ -65,15 +66,19 @@ def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
 
-    response_path = tmp_path / "response.json"
     env = os.environ.copy()
     env.update(
         {
             "IQOR_QUERY": "find related QA backlog work",
             "MORPHIK_BASE_URL": f"http://127.0.0.1:{server.server_port}",
-            "IQOR_RESPONSE_FILE": str(response_path),
+            "TMPDIR": str(tmp_path),
         }
     )
+    response_path = tmp_path / "response.json"
+    if explicit_response_path:
+        env["IQOR_RESPONSE_FILE"] = str(response_path)
+    else:
+        env.pop("IQOR_RESPONSE_FILE", None)
     try:
         completed = subprocess.run(
             [str(VERIFY_SCRIPT)],
@@ -104,6 +109,12 @@ def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path):
             ]
         },
     }
+
+    if not explicit_response_path:
+        saved_line = next(line for line in completed.stderr.splitlines() if line.startswith("Raw response saved to "))
+        response_path = Path(saved_line.removeprefix("Raw response saved to ").removesuffix("."))
+        assert response_path.parent == tmp_path
+        assert response_path.name.startswith("iqor-retrieval-response.")
 
     selected = json.loads(completed.stdout)
     assert len(selected) == 5

--- a/core/tests/unit/test_iqor_retrieval_script.py
+++ b/core/tests/unit/test_iqor_retrieval_script.py
@@ -1,0 +1,113 @@
+"""End-to-end request and response test for the iQor retrieval verifier."""
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_iqor_retrieval.sh"
+
+
+def _result(work_item_id: int, score: float, chunk_number: int = 0) -> dict:
+    return {
+        "content": f"QA backlog item {work_item_id}",
+        "score": score,
+        "document_id": f"doc-{work_item_id}",
+        "chunk_number": chunk_number,
+        "metadata": {
+            "project": "QA",
+            "work_item_type": "Product Backlog Item",
+            "work_item_id": work_item_id,
+        },
+        "content_type": "text/plain",
+        "filename": f"{work_item_id}.txt",
+        "download_url": None,
+        "is_padding": False,
+    }
+
+
+def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path):
+    if shutil.which("curl") is None or shutil.which("jq") is None:
+        pytest.skip("curl and jq are required")
+
+    captured = {}
+    response = [
+        _result(47501, 0.92),
+        _result(47501, 0.81, chunk_number=1),
+        _result(47502, 0.88),
+        _result(47503, 0.84),
+        _result(47504, 0.80),
+        _result(47505, 0.76),
+    ]
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["Content-Length"])
+            captured["path"] = self.path
+            captured["body"] = json.loads(self.rfile.read(length))
+            body = json.dumps(response).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    response_path = tmp_path / "response.json"
+    env = os.environ.copy()
+    env.update(
+        {
+            "IQOR_QUERY": "find related QA backlog work",
+            "MORPHIK_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+            "IQOR_RESPONSE_FILE": str(response_path),
+        }
+    )
+    try:
+        completed = subprocess.run(
+            [str(VERIFY_SCRIPT)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert captured["path"] == "/retrieve/chunks"
+    assert captured["body"] == {
+        "query": "find related QA backlog work",
+        "k": 50,
+        "min_score": 0,
+        "use_colpali": False,
+        "output_format": "text",
+        "filters": {
+            "$and": [
+                {"project": {"$eq": "QA"}},
+                {"work_item_type": {"$eq": "Product Backlog Item"}},
+                {"work_item_id": {"$ne": 47490}},
+            ]
+        },
+    }
+
+    selected = json.loads(completed.stdout)
+    assert len(selected) == 5
+    assert len({item["metadata"]["work_item_id"] for item in selected}) == 5
+    assert selected[0]["score"] == 0.92
+    assert selected[0]["source_id"] == "doc-47501:0"
+    assert json.loads(response_path.read_text()) == response

--- a/core/tests/unit/test_iqor_retrieval_script.py
+++ b/core/tests/unit/test_iqor_retrieval_script.py
@@ -52,6 +52,7 @@ def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path, 
             length = int(self.headers["Content-Length"])
             captured["path"] = self.path
             captured["body"] = json.loads(self.rfile.read(length))
+            captured["authorization"] = self.headers.get("Authorization")
             body = json.dumps(response).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -67,10 +68,23 @@ def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path, 
     thread.start()
 
     env = os.environ.copy()
+    real_curl = shutil.which("curl")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    curl_argv = tmp_path / "curl-argv"
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$CURL_ARGV_FILE"\nexec "{real_curl}" "$@"\n',
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
     env.update(
         {
             "IQOR_QUERY": "find related QA backlog work",
             "MORPHIK_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+            "MORPHIK_AUTH_TOKEN": "iqor-secret-token",
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "CURL_ARGV_FILE": str(curl_argv),
             "TMPDIR": str(tmp_path),
         }
     )
@@ -95,6 +109,9 @@ def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path, 
         thread.join(timeout=5)
 
     assert captured["path"] == "/retrieve/chunks"
+    assert captured["authorization"] == "Bearer iqor-secret-token"
+    assert "iqor-secret-token" not in curl_argv.read_text(encoding="utf-8")
+    assert list(tmp_path.glob("iqor-auth-header.*")) == []
     assert captured["body"] == {
         "query": "find related QA backlog work",
         "k": 50,

--- a/core/tests/unit/test_iqor_retrieval_script.py
+++ b/core/tests/unit/test_iqor_retrieval_script.py
@@ -122,3 +122,61 @@ def test_iqor_verifier_sends_contract_and_returns_five_distinct_items(tmp_path, 
     assert selected[0]["score"] == 0.92
     assert selected[0]["source_id"] == "doc-47501:0"
     assert json.loads(response_path.read_text()) == response
+
+
+@pytest.mark.parametrize("invalid_result", ["missing-work-item-id", "below-min-score"])
+def test_iqor_verifier_rejects_invalid_distinct_result(tmp_path, invalid_result):
+    if shutil.which("curl") is None or shutil.which("jq") is None:
+        pytest.skip("curl and jq are required")
+
+    response = [_result(47501, 0.92), _result(47502, 0.88), _result(47503, 0.84), _result(47504, 0.80)]
+    invalid = _result(47505, 0.76)
+    if invalid_result == "missing-work-item-id":
+        del invalid["metadata"]["work_item_id"]
+    else:
+        invalid["score"] = -0.01
+    response.append(invalid)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers["Content-Length"])
+            self.rfile.read(length)
+            body = json.dumps(response).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "IQOR_QUERY": "find related QA backlog work",
+            "MORPHIK_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+            "IQOR_RESPONSE_FILE": str(tmp_path / "response.json"),
+        }
+    )
+    try:
+        completed = subprocess.run(
+            [str(VERIFY_SCRIPT)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert completed.returncode == 1
+    assert "violated the metadata, exclusion, score, or source-ID contract" in completed.stderr

--- a/core/tests/unit/test_logs_no_egress.py
+++ b/core/tests/unit/test_logs_no_egress.py
@@ -1,0 +1,30 @@
+"""No-egress behavior for historical log requests."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+
+from core.models.auth import AuthContext  # noqa: E402
+from core.routes import logs  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_historical_logs_do_not_call_proxy_when_telemetry_is_disabled(monkeypatch):
+    async def unexpected_proxy_call(**kwargs):
+        raise AssertionError("historical log proxy must not be called")
+
+    monkeypatch.setattr(logs, "get_settings", lambda: SimpleNamespace(TELEMETRY_ENABLED=False))
+    monkeypatch.setattr(logs, "_query_proxy", unexpected_proxy_call)
+
+    result = await logs.get_logs(
+        auth=AuthContext(user_id="iqor-user", app_id="iqor-app"),
+        limit=100,
+        hours=24,
+        op_type=None,
+        status_filter=None,
+    )
+
+    assert result == []

--- a/core/tests/unit/test_retrieval_contract.py
+++ b/core/tests/unit/test_retrieval_contract.py
@@ -1,0 +1,35 @@
+"""Contract tests for retrieval thresholds used by on-prem callers."""
+
+import os
+
+os.environ.setdefault("POSTGRES_URI", "postgresql://user:pass@localhost:5432/test")
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+from core.models.chunk import DocumentChunk  # noqa: E402
+from core.services.document_service import _filter_chunks_by_min_score  # noqa: E402
+
+
+def _chunk(document_id: str, score: float) -> DocumentChunk:
+    return DocumentChunk(
+        document_id=document_id,
+        content=document_id,
+        embedding=[],
+        chunk_number=0,
+        score=score,
+    )
+
+
+def test_min_score_zero_keeps_zero_and_positive_scores():
+    chunks = [_chunk("negative", -0.01), _chunk("zero", 0.0), _chunk("positive", 0.75)]
+
+    filtered = _filter_chunks_by_min_score(chunks, 0.0)
+
+    assert [chunk.document_id for chunk in filtered] == ["zero", "positive"]
+
+
+def test_min_score_filters_on_the_final_score():
+    chunks = [_chunk("below", 0.49), _chunk("equal", 0.5), _chunk("above", 0.9)]
+
+    filtered = _filter_chunks_by_min_score(chunks, 0.5)
+
+    assert [chunk.document_id for chunk in filtered] == ["equal", "above"]

--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -7,9 +7,8 @@
 services:
   morphik:
     image: ghcr.io/morphik-org/morphik-core:${MORPHIK_VERSION:-latest}
-    container_name: morphik-app
     ports:
-      - "8000:8000"
+      - "${MORPHIK_API_PORT:-8000}:${MORPHIK_API_PORT:-8000}"
     environment:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-key-here}
       - POSTGRES_URI=postgresql+asyncpg://morphik:morphik@postgres:5432/morphik
@@ -17,6 +16,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LITELLM_LOCAL_MODEL_COST_MAP=${LITELLM_LOCAL_MODEL_COST_MAP:-True}
     volumes:
       # Configuration file (always mounted)
       - ./morphik.toml:/app/morphik.toml:ro
@@ -34,11 +34,12 @@ services:
     networks:
       - morphik-network
     env_file:
-      - .env
+      - path: .env
+        required: false
 
   worker:
     image: ghcr.io/morphik-org/morphik-core:${MORPHIK_VERSION:-latest}
-    # No fixed container_name: allows `docker compose up --scale worker=N` to run
+    # Project-scoped names allow `docker compose up --scale worker=N` to run
     # multiple worker processes (rendering is single-core per process).
     # The worker runs as a background job processor, so no ports are exposed.
     command: arq core.workers.ingestion_worker.WorkerSettings
@@ -49,6 +50,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LITELLM_LOCAL_MODEL_COST_MAP=${LITELLM_LOCAL_MODEL_COST_MAP:-True}
     volumes:
       # Configuration file (always mounted)
       - ./morphik.toml:/app/morphik.toml:ro
@@ -63,11 +65,11 @@ services:
     networks:
       - morphik-network
     env_file:
-      - .env
+      - path: .env
+        required: false
 
   redis:
     image: redis:7-alpine
-    container_name: morphik-redis
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes
@@ -82,14 +84,13 @@ services:
   postgres:
     # Uses a standard image with the pgvector extension pre-installed
     image: pgvector/pgvector:pg16
-    container_name: morphik-postgres
     environment:
       - POSTGRES_USER=morphik
       - POSTGRES_PASSWORD=morphik
       - POSTGRES_DB=morphik
-    ports:
-      - "5432:5432"
     volumes:
+      # Named volumes live outside the container and survive container recreation.
+      # Normal stop scripts must not pass --volumes to `docker compose down`.
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       # The -d flag is important to specify the database name for the readiness check
@@ -103,7 +104,6 @@ services:
 
   ollama:
     image: ollama/ollama:latest
-    container_name: morphik-ollama
     # Enable this profile to run Ollama for local models
     profiles:
       - ollama
@@ -116,7 +116,6 @@ services:
 
   ui:
     image: node:22-alpine
-    container_name: morphik-ui
     # Enable this profile to run the Web UI
     profiles:
       - ui
@@ -142,6 +141,7 @@ networks:
     driver: bridge
 
 volumes:
+  # Persistent deployment data. Remove only as an explicit destructive reset.
   postgres_data:
   redis_data:
   ollama_data:

--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -34,8 +34,7 @@ services:
     networks:
       - morphik-network
     env_file:
-      - path: .env
-        required: false
+      - "${MORPHIK_ENV_FILE:-.env}"
 
   worker:
     image: ghcr.io/morphik-org/morphik-core:${MORPHIK_VERSION:-latest}
@@ -65,8 +64,7 @@ services:
     networks:
       - morphik-network
     env_file:
-      - path: .env
-        required: false
+      - "${MORPHIK_ENV_FILE:-.env}"
 
   redis:
     image: redis:7-alpine

--- a/docs/iqor-on-prem.md
+++ b/docs/iqor-on-prem.md
@@ -9,10 +9,10 @@ executable test. A code path alone is not counted as a passing deployment check.
 
 | Finding | Status | Evidence | Owner |
 | --- | --- | --- | --- |
-| Routine stop deletes PostgreSQL data | Implemented; Docker proof pending | `test_normal_stop_preserves_volumes_and_stops_all_profiles` passes. The Docker recreation test is present but was skipped during this audit because the Docker daemon was not running. | Morphik Core |
+| Routine stop deletes PostgreSQL data | Verified in Docker | The recreation test calls `stop-morphik.sh` twice, restarts PostgreSQL, and reads the original document from the preserved volume. | Morphik Core |
 | Stop leaves optional containers behind | Implemented; runtime proof pending | `stop-morphik.sh` runs `down` with `--profile "*" --remove-orphans`. Static lifecycle tests pass. Runtime Docker verification is still pending. | Morphik Core |
 | Start rewrites Compose state and fixed container names collide | Implemented; static verification passed | The API port now uses `MORPHIK_API_PORT`; production services use Compose project-scoped names; static lifecycle tests and `docker compose config` pass. | Morphik Core |
-| Documents survive PostgreSQL container recreation | Test added, runtime result pending | `scripts/test_postgres_persistence.sh` inserts a document row, removes only the PostgreSQL container, recreates it, and checks the ID and metadata. Run it on a host with Docker running. | Morphik Core / iQor infrastructure |
+| Documents survive PostgreSQL container recreation | Verified in Docker | `scripts/test_postgres_persistence.sh` inserts a document row, recreates PostgreSQL, and checks the original ID and metadata. | Morphik Core / iQor infrastructure |
 | Text update preserves document identity and existing metadata | Verified in a unit test | `test_queued_text_update_preserves_identity_metadata_and_queues_reindex` passes. | Morphik Core |
 | Text update queues changed content for re-indexing and exposes processing status | Partially verified | The unit test proves the replacement object and `process_ingestion_job` payload use the same document ID and that the returned status is `processing`. Existing SDK status tests pass. No end-to-end test in this audit proves the changed text is retrievable after the worker finishes. | Morphik Core |
 | Text update prevents lost updates | Fails | There is no content revision precondition. Every update uses ARQ job ID `ingest:{document_id}`. A second update can receive a successful API response while `enqueue_job` returns `None`, and the first queued job may refer to an object the second update deleted. | Morphik Core, then iQor caller adoption |
@@ -57,8 +57,9 @@ Run this on a disposable Docker host or CI runner:
 ```
 
 The test uses a unique project name beginning with `morphik-persistence-test-`. It starts only PostgreSQL, creates a
-`documents` table with the Morphik identity and metadata fields, inserts the 47490 probe row, removes the container,
-starts a new container against the same volume, and checks for:
+`documents` table with the Morphik identity and metadata fields, inserts the 47490 probe row, and checks it after direct
+container recreation. It then calls `stop-morphik.sh` twice, starts PostgreSQL again against the same volume, and checks
+for:
 
 ```text
 iqor-persistence-probe|QA|47490
@@ -68,6 +69,13 @@ It deletes only its isolated test project and volume on exit. The pytest entry p
 
 ```bash
 .venv/bin/pytest -q core/tests/integration/test_docker_postgres_persistence.py
+```
+
+Captured on 2026-09-02 with Docker Engine 27.4.0:
+
+```text
+PASS: document identity and metadata survived container recreation and repeated stop/start.
+1 passed
 ```
 
 ## Document update contract
@@ -198,10 +206,10 @@ MORPHIK_AUTH_TOKEN='<token>' \
 ./scripts/verify_iqor_retrieval.sh
 ```
 
-The script saves the raw response to `iqor-retrieval-response.json`, validates the filters, exclusion, scores, and
-source fields, then prints five deduplicated items. Use `IQOR_WORK_ITEM_ID_JSON='"47490"'` if IDs are strings. The field
-names, backlog type value, candidate count, output path, and ColPali flag are also configurable through the variables
-listed at the top of the script.
+The script saves the raw response in the operating system's temporary directory unless `IQOR_RESPONSE_FILE` is set.
+It prints the chosen path to stderr, validates the filters, exclusion, scores, and source fields, then prints five
+deduplicated items. Use `IQOR_WORK_ITEM_ID_JSON='"47490"'` if IDs are strings. Set `IQOR_RESPONSE_FILE` only to an
+approved location outside the repository when iQor needs to retain the raw customer response.
 
 ## On-prem data boundary
 
@@ -260,6 +268,7 @@ The iQor MCP wrapper and existing UI are not present in this repository, so this
 - `stop-morphik.sh`: checked-in, repeatable stop that activates every profile and preserves volumes.
 - `install_docker.sh` and `install_docker.ps1`: generate the safe start/stop behavior and local LiteLLM cost map setting.
 - `.env.example`: project-name migration warning and local LiteLLM cost map setting.
+- `.gitignore`: defense-in-depth exclusion for explicitly named iQor retrieval captures.
 - `DOCKER.md`: safe stop and explicit destructive reset documentation.
 - `core/services/document_service.py`: enforce `min_score` after final scoring.
 - `core/tests/unit/test_docker_lifecycle.py`: lifecycle and installer guards.
@@ -301,7 +310,7 @@ LITELLM_LOCAL_MODEL_COST_MAP=True \
 .venv/bin/pytest -q sdks/python/morphik/tests/test_document_status.py
 ```
 
-Run the pending Docker proof on a host with its daemon running:
+Run the Docker proof on a host with its daemon running:
 
 ```bash
 .venv/bin/pytest -q core/tests/integration/test_docker_postgres_persistence.py

--- a/docs/iqor-on-prem.md
+++ b/docs/iqor-on-prem.md
@@ -179,8 +179,8 @@ applies `min_score` after vector scoring and optional reranking, before zero-sco
 
 Core can return several chunks from one work item. The MCP wrapper should keep the highest-scoring chunk for each
 `metadata.work_item_id`, sort those representatives by score, and return the first five. It must reject a result if the
-project or type is wrong, the current work item is present, a source ID is missing, or fewer than five distinct IDs are
-available.
+project or type is wrong, the current work item is present, the work-item ID is missing or has the wrong type, a source
+ID is missing, or fewer than five distinct IDs are available.
 
 ### Error behavior
 
@@ -226,6 +226,7 @@ The stock production configuration is not a no-egress configuration.
 | ColPali API or parser API mode | Local by default | Document images, text, or file bytes go to every configured Morphik embedding API endpoint when API mode is selected. |
 | S3 or Morphik multivector storage | Local PostgreSQL and filesystem by default | Source objects go to S3; vectors and chunk content can go to Turbopuffer when those providers are selected. |
 | Morphik telemetry | Enabled by default unless `TELEMETRY=false` | Compressed operation events go to `https://logs.morphik.ai`. Query and folder strings are redacted, but events include installation, user/app IDs, operation fields, document IDs or filenames for some operations, timings, and error strings. |
+| Historical log lookup | `GET /logs?hours=<value greater than 4>` while telemetry is enabled | The app ID, start time, limit, operation type, and status filter go to `https://logs.morphik.ai`. With `TELEMETRY=false`, this branch returns an empty list without contacting the proxy. |
 | Sentry | Only when `SENTRY_DSN` is set | Errors, traces, profiles, request context, and default PII go to the configured Sentry project. |
 | LiteLLM model-price map | Disabled by default in this branch's production Compose environment | Without `LITELLM_LOCAL_MODEL_COST_MAP=True`, process import downloads a JSON map from GitHub. This request contains no customer document data. |
 | Model and image downloads | First install or uncached local model start | Container images and model weights come from GHCR, Docker Hub, Hugging Face, Ollama, or the configured registry. Customer documents are not part of these downloads. |
@@ -271,7 +272,9 @@ The iQor MCP wrapper and existing UI are not present in this repository, so this
 - `.gitignore`: defense-in-depth exclusion for explicitly named iQor retrieval captures.
 - `DOCKER.md`: safe stop and explicit destructive reset documentation.
 - `core/services/document_service.py`: enforce `min_score` after final scoring.
+- `core/routes/logs.py`: avoid the historical Morphik log proxy when telemetry is disabled.
 - `core/tests/unit/test_docker_lifecycle.py`: lifecycle and installer guards.
+- `core/tests/unit/test_logs_no_egress.py`: historical-log no-egress test.
 - `core/tests/integration/test_docker_postgres_persistence.py` and `scripts/test_postgres_persistence.sh`: container
   recreation test.
 - `core/tests/unit/test_ingestion_service_metadata_update.py`: identity, metadata, status, and re-index queue test.
@@ -307,6 +310,7 @@ Run the tests that passed during this audit:
 LITELLM_LOCAL_MODEL_COST_MAP=True \
   .venv/bin/pytest -q core/tests/unit/test_retrieval_contract.py
 .venv/bin/pytest -q core/tests/unit/test_iqor_retrieval_script.py
+.venv/bin/pytest -q core/tests/unit/test_logs_no_egress.py
 .venv/bin/pytest -q sdks/python/morphik/tests/test_document_status.py
 ```
 

--- a/docs/iqor-on-prem.md
+++ b/docs/iqor-on-prem.md
@@ -1,0 +1,338 @@
+# iQor on-prem deployment audit
+
+Audit baseline: `origin/main` at `8c51b8d` on 2026-09-02.
+
+This document separates Morphik Core behavior from iQor's MCP wrapper and UI. It also records which findings have an
+executable test. A code path alone is not counted as a passing deployment check.
+
+## Status
+
+| Finding | Status | Evidence | Owner |
+| --- | --- | --- | --- |
+| Routine stop deletes PostgreSQL data | Implemented; Docker proof pending | `test_normal_stop_preserves_volumes_and_stops_all_profiles` passes. The Docker recreation test is present but was skipped during this audit because the Docker daemon was not running. | Morphik Core |
+| Stop leaves optional containers behind | Implemented; runtime proof pending | `stop-morphik.sh` runs `down` with `--profile "*" --remove-orphans`. Static lifecycle tests pass. Runtime Docker verification is still pending. | Morphik Core |
+| Start rewrites Compose state and fixed container names collide | Implemented; static verification passed | The API port now uses `MORPHIK_API_PORT`; production services use Compose project-scoped names; static lifecycle tests and `docker compose config` pass. | Morphik Core |
+| Documents survive PostgreSQL container recreation | Test added, runtime result pending | `scripts/test_postgres_persistence.sh` inserts a document row, removes only the PostgreSQL container, recreates it, and checks the ID and metadata. Run it on a host with Docker running. | Morphik Core / iQor infrastructure |
+| Text update preserves document identity and existing metadata | Verified in a unit test | `test_queued_text_update_preserves_identity_metadata_and_queues_reindex` passes. | Morphik Core |
+| Text update queues changed content for re-indexing and exposes processing status | Partially verified | The unit test proves the replacement object and `process_ingestion_job` payload use the same document ID and that the returned status is `processing`. Existing SDK status tests pass. No end-to-end test in this audit proves the changed text is retrievable after the worker finishes. | Morphik Core |
+| Text update prevents lost updates | Fails | There is no content revision precondition. Every update uses ARQ job ID `ingest:{document_id}`. A second update can receive a successful API response while `enqueue_job` returns `None`, and the first queued job may refer to an object the second update deleted. | Morphik Core, then iQor caller adoption |
+| `min_score` affects retrieval | Fixed and unit verified in this branch | `test_min_score_zero_keeps_zero_and_positive_scores` and `test_min_score_filters_on_the_final_score` pass. | Morphik Core |
+| Work item 47490 returns five distinct QA backlog items | Not verified | The repository has no iQor corpus, query text, auth token, or captured response. `scripts/verify_iqor_retrieval.sh` captures and validates the response on iQor's deployment. | iQor MCP wrapper / iQor acceptance test |
+| Default Docker config keeps document and query data on premises | Fails by default | `morphik.docker.toml` selects OpenAI for completion and standard embeddings. Telemetry is enabled unless `TELEMETRY=false`. See the data boundary below. | Joint configuration decision |
+| Core, MCP wrapper, and UI responsibilities are separated | Documented | See the ownership table below. The iQor MCP wrapper and existing iQor UI are not in this repository. | Joint |
+
+## Lifecycle and persistence contract
+
+The production Compose file stores PostgreSQL data in the `postgres_data` named volume. Uploaded source files use the
+host bind mount `./storage`. Neither location is part of the PostgreSQL or Morphik container writable layer.
+
+iQor should set a stable `COMPOSE_PROJECT_NAME`, such as `iqor-morphik`, before the first production start. On an
+existing deployment, keep the current project name. Changing it later selects a different named volume and makes the
+old database appear missing even though Docker still has the original volume.
+
+Normal lifecycle commands are safe to repeat:
+
+```bash
+./start-morphik.sh
+./start-morphik.sh
+./stop-morphik.sh
+./stop-morphik.sh
+```
+
+`stop-morphik.sh` removes containers and the Compose network. It does not remove named volumes. The explicit reset
+command below deletes PostgreSQL, Redis, downloaded model state, and UI build volumes:
+
+```bash
+docker compose -f docker-compose.run.yml --profile "*" down --volumes --remove-orphans
+```
+
+Treat that command as destructive. Back up PostgreSQL and `./storage` first.
+
+### Automated recreation test
+
+Run this on a disposable Docker host or CI runner:
+
+```bash
+./scripts/test_postgres_persistence.sh
+```
+
+The test uses a unique project name beginning with `morphik-persistence-test-`. It starts only PostgreSQL, creates a
+`documents` table with the Morphik identity and metadata fields, inserts the 47490 probe row, removes the container,
+starts a new container against the same volume, and checks for:
+
+```text
+iqor-persistence-probe|QA|47490
+```
+
+It deletes only its isolated test project and volume on exit. The pytest entry point is:
+
+```bash
+.venv/bin/pytest -q core/tests/integration/test_docker_postgres_persistence.py
+```
+
+## Document update contract
+
+iQor's `documents.updateText` call maps to:
+
+```http
+POST /documents/{document_id}/update_text
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "content": "corrected text",
+  "filename": "optional-name.txt",
+  "metadata": {},
+  "metadata_types": {},
+  "use_colpali": false
+}
+```
+
+Observed behavior:
+
+- The path `document_id` remains the document `external_id`.
+- Omitted metadata is preserved. Supplied metadata is merged. Reserved identity, folder, app, owner, and end-user fields
+  cannot be changed through this endpoint.
+- Morphik uploads the replacement content, changes status to `processing`, and queues `process_ingestion_job`.
+- The worker deletes old vector chunks before storing replacement chunks. It marks the document `completed` after the
+  write, or `failed` after terminal errors.
+- `GET /documents/{document_id}/status` returns `document_id`, `status`, `filename`, `created_at`, `updated_at`, optional
+  `progress`, and optional `error`.
+
+The lost-update criterion does not pass. The update request has no `expected_version` or `If-Match` value, and the
+document does not have a general content revision that the database checks atomically. The queue key is also shared by
+all updates for a document. A proper fix needs all of the following in one change:
+
+1. Return a content revision on document reads and update responses.
+2. Require or accept that revision on updates and return HTTP 409 when it is stale.
+3. Include the accepted revision in the ARQ job ID and payload.
+4. Make workers skip stale revisions before progress, chunk deletion, status, or failure writes.
+5. Retain old source objects until the accepted revision completes, then clean them up.
+
+Adding only a request version check would still leave older workers able to overwrite newer chunks or status.
+
+## Retrieval contract for work item 47490
+
+Morphik Core's evidence endpoint is `POST /retrieve/chunks`. For iQor's acceptance test, use an over-fetched candidate
+set and let the MCP wrapper deduplicate by work item ID. Core's `k` counts chunks, not distinct work items.
+
+The exact metadata key names and the ID type must match ingestion. This example assumes `project`, `work_item_type`, and
+numeric `work_item_id` metadata:
+
+```json
+{
+  "query": "<the retrieval text for work item 47490>",
+  "k": 50,
+  "min_score": 0.0,
+  "use_colpali": false,
+  "output_format": "text",
+  "filters": {
+    "$and": [
+      {"project": {"$eq": "QA"}},
+      {"work_item_type": {"$eq": "Product Backlog Item"}},
+      {"work_item_id": {"$ne": 47490}}
+    ]
+  }
+}
+```
+
+If ingestion stored `work_item_id` as a string, use `"47490"` in the filter. A numeric predicate does not match a string
+field.
+
+The response is a JSON array sorted by descending relevance before any wrapper-side grouping:
+
+```json
+[
+  {
+    "content": "matching chunk text",
+    "score": 0.82,
+    "document_id": "persistent-morphik-document-id",
+    "chunk_number": 3,
+    "metadata": {
+      "project": "QA",
+      "work_item_type": "Product Backlog Item",
+      "work_item_id": 47501
+    },
+    "content_type": "text/plain",
+    "filename": "47501.txt",
+    "download_url": null,
+    "is_padding": false
+  }
+]
+```
+
+Use `document_id` plus `chunk_number` as the stable evidence source ID, for example
+`persistent-morphik-document-id:3`. Keep the numeric `score` alongside the source. Higher is better. Standard pgvector
+cosine scores and the configured normalized reranker are in the 0 to 1 range. Other multivector implementations may
+not be calibrated identically, so iQor should validate any nonzero threshold against its chosen backend. This branch
+applies `min_score` after vector scoring and optional reranking, before zero-score padding is added.
+
+Core can return several chunks from one work item. The MCP wrapper should keep the highest-scoring chunk for each
+`metadata.work_item_id`, sort those representatives by score, and return the first five. It must reject a result if the
+project or type is wrong, the current work item is present, a source ID is missing, or fewer than five distinct IDs are
+available.
+
+### Error behavior
+
+| Condition | HTTP/result behavior |
+| --- | --- |
+| Missing query and image, both supplied, invalid field shape, or `k <= 0` | FastAPI validation response, HTTP 422 |
+| Invalid metadata operator or operand | `{"detail":"..."}`, HTTP 400 |
+| Invalid image or image retrieval without ColPali | `{"detail":"..."}`, HTTP 400 |
+| Invalid or unauthorized scope | `{"detail":"..."}`, normally HTTP 403 |
+| Valid request with no authorized matching documents | `[]`, HTTP 200 |
+| Unhandled API or provider error | HTTP 500 |
+| Some vector-store query failures | The current stores log the backend error and may return `[]` with HTTP 200 |
+
+The last behavior means the MCP wrapper must not treat an empty 200 as proof that no matching backlog items exist. It
+should log the Morphik request ID and check service logs or health when an expected corpus returns no results.
+
+Capture and validate the real response with:
+
+```bash
+IQOR_QUERY='<query used by the PO Agent for work item 47490>' \
+MORPHIK_BASE_URL='https://customer-hosted-morphik.example' \
+MORPHIK_AUTH_TOKEN='<token>' \
+./scripts/verify_iqor_retrieval.sh
+```
+
+The script saves the raw response to `iqor-retrieval-response.json`, validates the filters, exclusion, scores, and
+source fields, then prints five deduplicated items. Use `IQOR_WORK_ITEM_ID_JSON='"47490"'` if IDs are strings. The field
+names, backlog type value, candidate count, output path, and ColPali flag are also configurable through the variables
+listed at the top of the script.
+
+## On-prem data boundary
+
+The stock production configuration is not a no-egress configuration.
+
+| Path | Default or trigger | Data sent outside the Morphik containers |
+| --- | --- | --- |
+| Standard ingestion embeddings | `morphik.docker.toml` selects `openai_embedding` | Parsed document chunks go to OpenAI. |
+| Retrieval embeddings | Same embedding selection | The user's retrieval query goes to OpenAI. |
+| Query completion | `openai_gpt4-1-mini` is the default completion model | Query, retrieved context, prompt, and optional chat history go to OpenAI. |
+| Contextual chunking | Off by default; model defaults to OpenAI if enabled | The document text and each chunk go to the selected completion provider. |
+| Video frame descriptions | Frame sampling is off by default | Sampled images and prompt text go to the selected vision provider when enabled. |
+| Video transcription | Only when `ASSEMBLYAI_API_KEY` is set | Audio goes to AssemblyAI. |
+| ColPali API or parser API mode | Local by default | Document images, text, or file bytes go to every configured Morphik embedding API endpoint when API mode is selected. |
+| S3 or Morphik multivector storage | Local PostgreSQL and filesystem by default | Source objects go to S3; vectors and chunk content can go to Turbopuffer when those providers are selected. |
+| Morphik telemetry | Enabled by default unless `TELEMETRY=false` | Compressed operation events go to `https://logs.morphik.ai`. Query and folder strings are redacted, but events include installation, user/app IDs, operation fields, document IDs or filenames for some operations, timings, and error strings. |
+| Sentry | Only when `SENTRY_DSN` is set | Errors, traces, profiles, request context, and default PII go to the configured Sentry project. |
+| LiteLLM model-price map | Disabled by default in this branch's production Compose environment | Without `LITELLM_LOCAL_MODEL_COST_MAP=True`, process import downloads a JSON map from GitHub. This request contains no customer document data. |
+| Model and image downloads | First install or uncached local model start | Container images and model weights come from GHCR, Docker Hub, Hugging Face, Ollama, or the configured registry. Customer documents are not part of these downloads. |
+| Public-IP lookup | Only when the local URI generation path requests automatic host discovery | The server calls `checkip.amazonaws.com`; no document body is sent. |
+
+For a no-egress iQor deployment:
+
+- Set `TELEMETRY=false`, leave `SENTRY_DSN` empty, and keep
+  `LITELLM_LOCAL_MODEL_COST_MAP=True` in `.env`.
+- Point the completion and embedding model entries at customer-hosted Ollama or another internal OpenAI-compatible
+  service. Do not leave `openai_embedding` or `openai_gpt4-1-mini` selected.
+- Keep `colpali_mode="local"` or `"off"` and `parser_mode="local"`.
+- Keep storage `local`, vector store `pgvector`, and multivector store `postgres` unless iQor approves the alternative
+  destination.
+- Do not set OpenAI, Anthropic, Gemini, AssemblyAI, Turbopuffer, AWS, or Sentry credentials unless that provider is
+  inside the approved boundary.
+- Mirror container images and model weights into iQor-approved registries if the runtime network has no internet
+  access.
+- Enforce the policy with an egress-deny rule. Configuration review alone cannot prove that a host has no outbound
+  path.
+
+## Ownership split
+
+| Morphik Core owns | iQor MCP wrapper owns | iQor UI owns |
+| --- | --- | --- |
+| Durable PostgreSQL and source-file mounts | Translating PO Agent inputs into the documented request | Pointing at the customer-hosted MCP or Morphik endpoint |
+| Safe start/stop scripts and opt-in destructive reset | Applying the exact QA, backlog type, and current-ID filters | Sending corrected text through the existing update action |
+| Authentication, metadata filtering, vector scoring, minimum score, chunk source fields | Over-fetching chunks, deduplicating by work item ID, returning exactly five, and preserving score/source ID | Showing processing, completed, failed, conflict, and retrieval error states |
+| Stable document identity, update processing state, re-index worker, and a future revision conflict contract | Mapping Morphik errors into MCP tool errors without turning empty results into success | Polling document status after an update and preventing duplicate submissions while processing |
+| Provider selection points and documented outbound integrations | No model or embedding calls outside Morphik Core | No direct model or storage-provider calls unless iQor explicitly designs them |
+
+The iQor MCP wrapper and existing UI are not present in this repository, so this branch does not change or test them.
+
+## Files changed by this audit
+
+- `docker-compose.run.yml`: project-scoped service names, parameterized API port, no host-published PostgreSQL port,
+  persistent-volume comments, optional `.env`, and local LiteLLM cost map.
+- `start-morphik.sh`: repeatable startup without temporary Compose files, profile support, argument validation, and orphan
+  cleanup.
+- `stop-morphik.sh`: checked-in, repeatable stop that activates every profile and preserves volumes.
+- `install_docker.sh` and `install_docker.ps1`: generate the safe start/stop behavior and local LiteLLM cost map setting.
+- `.env.example`: project-name migration warning and local LiteLLM cost map setting.
+- `DOCKER.md`: safe stop and explicit destructive reset documentation.
+- `core/services/document_service.py`: enforce `min_score` after final scoring.
+- `core/tests/unit/test_docker_lifecycle.py`: lifecycle and installer guards.
+- `core/tests/integration/test_docker_postgres_persistence.py` and `scripts/test_postgres_persistence.sh`: container
+  recreation test.
+- `core/tests/unit/test_ingestion_service_metadata_update.py`: identity, metadata, status, and re-index queue test.
+- `core/tests/unit/test_retrieval_contract.py`: minimum-score tests.
+- `scripts/verify_iqor_retrieval.sh`: captured-response acceptance check for work item 47490.
+
+## Reproduction and verification commands
+
+Confirm the audit base:
+
+```bash
+git fetch origin --prune
+git rev-list --left-right --count HEAD...origin/main
+git log -1 --oneline origin/main
+```
+
+The audit began with `0 0` and `8c51b8d` before these branch changes.
+
+Validate the lifecycle scripts and rendered production Compose model without starting containers:
+
+```bash
+bash -n start-morphik.sh stop-morphik.sh install_docker.sh \
+  scripts/test_postgres_persistence.sh scripts/verify_iqor_retrieval.sh
+MORPHIK_API_PORT=8123 MORPHIK_VERSION=test \
+  docker compose -f docker-compose.run.yml --profile "*" config
+```
+
+Run the tests that passed during this audit:
+
+```bash
+.venv/bin/pytest -q core/tests/unit/test_docker_lifecycle.py
+.venv/bin/pytest -q core/tests/unit/test_ingestion_service_metadata_update.py
+LITELLM_LOCAL_MODEL_COST_MAP=True \
+  .venv/bin/pytest -q core/tests/unit/test_retrieval_contract.py
+.venv/bin/pytest -q core/tests/unit/test_iqor_retrieval_script.py
+.venv/bin/pytest -q sdks/python/morphik/tests/test_document_status.py
+```
+
+Run the pending Docker proof on a host with its daemon running:
+
+```bash
+.venv/bin/pytest -q core/tests/integration/test_docker_postgres_persistence.py
+# or
+./scripts/test_postgres_persistence.sh
+```
+
+Reproduce the original destructive behavior on an old installation only after taking a backup. Inspect the generated
+script rather than running it against customer data:
+
+```bash
+rg -n 'down.*--volumes' stop-morphik.sh install_docker.sh install_docker.ps1
+```
+
+On the audited base, both installers generated a normal stop containing `down --volumes --remove-orphans`. On this
+branch, the command returns no matches for the production stop paths.
+
+## Remaining questions for iQor
+
+1. What exact metadata keys and types are stored for project, work-item type, and work-item ID? Is the backlog value
+   exactly `Product Backlog Item`?
+2. What exact query text does the PO Agent derive from work item 47490, and which embedding, reranker, and ColPali
+   settings must the acceptance environment use?
+3. Does "five distinct" mean five work item IDs even when one item has several matching chunks? The proposed wrapper
+   contract assumes yes.
+4. Should the MCP response return one best chunk per work item or all supporting chunks under each of the five items?
+5. Can iQor change `documents.updateText` to send and handle a content revision, including HTTP 409, once Morphik adds
+   the lost-update fix?
+6. Must the deployment have zero outbound network access, or are approved internal Azure/OpenAI, S3, telemetry, or
+   registry endpoints allowed?
+7. Who owns PostgreSQL backups, restore drills, retention, encryption keys, and the stable `COMPOSE_PROJECT_NAME` in
+   customer infrastructure?
+8. Will iQor use the bundled Redis container? Redis persistence is retained now, but queued jobs are not a substitute
+   for a database backup or an update revision contract.

--- a/docs/iqor-on-prem.md
+++ b/docs/iqor-on-prem.md
@@ -209,7 +209,9 @@ MORPHIK_AUTH_TOKEN='<token>' \
 The script saves the raw response in the operating system's temporary directory unless `IQOR_RESPONSE_FILE` is set.
 It prints the chosen path to stderr, validates the filters, exclusion, scores, and source fields, then prints five
 deduplicated items. Use `IQOR_WORK_ITEM_ID_JSON='"47490"'` if IDs are strings. Set `IQOR_RESPONSE_FILE` only to an
-approved location outside the repository when iQor needs to retain the raw customer response.
+approved location outside the repository when iQor needs to retain the raw customer response. The bearer token is
+written to a mode-600 temporary header file so it does not appear in curl's process arguments, and the script deletes
+that file on exit.
 
 ## On-prem data boundary
 

--- a/docs/iqor-on-prem.md
+++ b/docs/iqor-on-prem.md
@@ -262,7 +262,7 @@ The iQor MCP wrapper and existing UI are not present in this repository, so this
 ## Files changed by this audit
 
 - `docker-compose.run.yml`: project-scoped service names, parameterized API port, no host-published PostgreSQL port,
-  persistent-volume comments, optional `.env`, and local LiteLLM cost map.
+  persistent-volume comments, Compose V2-compatible `.env` loading, and local LiteLLM cost map.
 - `start-morphik.sh`: repeatable startup without temporary Compose files, profile support, argument validation, and orphan
   cleanup.
 - `stop-morphik.sh`: checked-in, repeatable stop that activates every profile and preserves volumes.
@@ -295,7 +295,7 @@ Validate the lifecycle scripts and rendered production Compose model without sta
 ```bash
 bash -n start-morphik.sh stop-morphik.sh install_docker.sh \
   scripts/test_postgres_persistence.sh scripts/verify_iqor_retrieval.sh
-MORPHIK_API_PORT=8123 MORPHIK_VERSION=test \
+MORPHIK_API_PORT=8123 MORPHIK_VERSION=test MORPHIK_ENV_FILE=/dev/null \
   docker compose -f docker-compose.run.yml --profile "*" config
 ```
 

--- a/install_docker.ps1
+++ b/install_docker.ps1
@@ -175,7 +175,10 @@ function Ensure-EnvFile {
     "JWT_SECRET_KEY=$jwt",
     "",
     "# Local URI password for secure URI generation (required for creating connection URIs)",
-    "LOCAL_URI_PASSWORD="
+    "LOCAL_URI_PASSWORD=",
+    "",
+    "# Prevent LiteLLM from downloading its model-price map at process startup.",
+    "LITELLM_LOCAL_MODEL_COST_MAP=True"
   ) -join [Environment]::NewLine
   Set-Content -Path .env -Value $envContent
 
@@ -368,12 +371,6 @@ function Get-ApiPortFromToml {
   return $port
 }
 
-function Update-Port-Mapping($apiPort) {
-  $composeContent = Get-Content $COMPOSE -Raw
-  $composeContent = $composeContent -replace '"8000:8000"', '"{0}:{0}"' -f $apiPort
-  [System.IO.File]::WriteAllText($COMPOSE, $composeContent, (New-Object System.Text.UTF8Encoding($false)))
-}
-
 function Maybe-Install-UI($apiPort) {
   Write-Host ""; Write-Info "Morphik includes an optional Admin UI."
   $ans = Read-Host "Would you like to install the Admin UI? (y/N)"
@@ -403,9 +400,10 @@ function Maybe-Install-UI($apiPort) {
 
 function Start-Stack($apiPort, $ui) {
   Write-Step "Starting the Morphik stack... (first run can take a few minutes)"
+  $env:MORPHIK_API_PORT = $apiPort
   $args = @('-f', $COMPOSE)
   if ($ui) { $args += @('--profile','ui') }
-  docker compose @args up -d
+  docker compose @args up -d --remove-orphans
   Write-Ok "Morphik has been started!"
   Write-Info ("Health check: http://localhost:{0}/health" -f $apiPort)
   Write-Info ("API docs:     http://localhost:{0}/docs"   -f $apiPort)
@@ -436,13 +434,8 @@ function Start-Stack($apiPort, $ui) {
     "  if (`$p) { `$desired = `$p }",
     "}",
     "",
-    "# Update port mapping in compose file if needed",
-    "`$compose = Get-Content 'docker-compose.run.yml' -Raw",
-    "if (`$compose -match '`"(\\d+):(\\d+)`"') {",
-    "  `$current = `$Matches[1]",
-    "  if (`$current -ne `$desired) {",
-    "    `$compose = `$compose -replace `"`$(`$current`):`$(`$current`)`", `"`$(`$desired`):`$(`$desired`)`"",
-    "    Set-Content 'docker-compose.run.yml' -Value `$compose  } }",
+    "# Pass the configured port to Compose without rewriting the compose file",
+    "`$env:MORPHIK_API_PORT = `$desired",
     "",
     "# Warn if multimodal embeddings disabled",
     "if (Test-Path 'morphik.toml') {",
@@ -458,7 +451,7 @@ function Start-Stack($apiPort, $ui) {
     "",
     "`$args = @('-f','docker-compose.run.yml')",
     "if (`$ui) { `$args += @('--profile','ui') }",
-    "docker compose @args up -d",
+    "docker compose @args up -d --remove-orphans",
     "Write-Host `"Morphik is running on http://localhost:`$(`$desired)`""
   ) -join [Environment]::NewLine
   Set-Content -Path 'start-morphik.ps1' -Value $start }
@@ -471,24 +464,10 @@ function Start-Stack($apiPort, $ui) {
     "  Write-Error 'docker-compose.run.yml not found. Run this script from your Morphik install directory.'",
     "}",
     "",
-    "`$profiles = @()",
-    "if (Test-Path '.env') {",
-    "  `$envLines = Get-Content .env",
-    "  `$match = `$envLines | Select-String '^COMPOSE_PROFILES=' | Select-Object -First 1",
-    "  if (`$match) {",
-    "    `$value = `$envLines[`$match.LineNumber - 1].Split('=')[1]",
-    "    `$value.Split(',') | ForEach-Object {",
-    "      `$p = `$_.Trim()",
-    "      if (`$p) { `$profiles += @('--profile', `$p) }",
-    "    }",
-    "  } elseif (`$envLines | Select-String 'UI_INSTALLED=true') {",
-    "    `$profiles += @('--profile','ui')",
-    "  }",
-    "}",
-    "",
-    "`$args = @('-f','docker-compose.run.yml') + `$profiles + @('down','--volumes','--remove-orphans')",
+    "# Activate every profile so optional containers stop; preserve all named volumes.",
+    "`$args = @('-f','docker-compose.run.yml','--profile','*','down','--remove-orphans')",
     "docker compose @args",
-    "Write-Host 'Morphik services stopped and cleaned up.'"
+    "Write-Host 'Morphik services stopped. Persistent named volumes were preserved.'"
   ) -join [Environment]::NewLine
   Set-Content -Path 'stop-morphik.ps1' -Value $stop
 
@@ -515,7 +494,6 @@ Update-GPU-Options
 Enable-Config-Mount
 
 $apiPort = Get-ApiPortFromToml
-Update-Port-Mapping -apiPort $apiPort
 
 $uiInstalled = Maybe-Install-UI -apiPort $apiPort
 Start-Stack -apiPort $apiPort -ui $uiInstalled
@@ -523,7 +501,7 @@ Start-Stack -apiPort $apiPort -ui $uiInstalled
 Write-Host ""
 Write-Ok "Management commands:"
 Write-Info "View logs:    docker compose -f $COMPOSE $(if($uiInstalled){'--profile ui '})logs -f"
-Write-Info "Stop services: ./stop-morphik.ps1   (runs docker compose down --volumes --remove-orphans)"
+Write-Info "Stop services: ./stop-morphik.ps1   (preserves PostgreSQL and other named volumes)"
 Write-Info "Restart:      ./start-morphik.ps1"
 
 Write-Host ""

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -477,7 +477,7 @@ cat > start-morphik.sh << 'EOF'
 set -euo pipefail
 
 # Purpose: Production startup script for Morphik
-# Automatically updates port mapping from morphik.toml and includes UI if installed
+# Passes the port from morphik.toml to Compose and includes UI if installed
 # Usage: ./start-morphik.sh [--version <tag>]
 
 # Color functions
@@ -512,7 +512,7 @@ done
 
 # Load MORPHIK_VERSION from .env if not set via flag
 if [ -z "${MORPHIK_VERSION:-}" ] && [ -f ".env" ]; then
-    MORPHIK_VERSION=$(grep "^MORPHIK_VERSION=" .env 2>/dev/null | tail -n1 | cut -d= -f2-)
+    MORPHIK_VERSION=$(sed -n 's/^MORPHIK_VERSION=//p' .env | tail -n1)
 fi
 export MORPHIK_VERSION="${MORPHIK_VERSION:-latest}"
 

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -182,6 +182,9 @@ LOCAL_URI_PASSWORD=
 
 # Morphik image version (use a date tag like 2025-02-01 to pin, or "latest" for newest)
 MORPHIK_VERSION=${MORPHIK_VERSION}
+
+# Prevent LiteLLM from downloading its model-price map at process startup.
+LITELLM_LOCAL_MODEL_COST_MAP=True
 EOF
 
 print_info "Morphik supports 100s of models including OpenAI, Anthropic (Claude), Google Gemini, local models, and even custom models!"
@@ -401,10 +404,9 @@ print_success "Configuration has been set up at 'morphik.toml'."
 print_info "You can edit this file to customize models, ports, or other settings."
 read -p "Press [Enter] to continue with the current configuration or edit 'morphik.toml' in another terminal first..." < /dev/tty
 
-# Update port mapping in docker-compose.run.yml to match morphik.toml
+# Pass the configured API port to Docker Compose without rewriting the compose file.
 API_PORT=$(awk '/^\[api\]/{flag=1; next} /^\[/{flag=0} flag && /^port[[:space:]]*=/ {gsub(/^port[[:space:]]*=[[:space:]]*/, ""); print; exit}' morphik.toml 2>/dev/null || echo "8000")
-sed -i.bak "s|\"8000:8000\"|\"${API_PORT}:${API_PORT}\"|g" "$COMPOSE_FILE"
-rm -f ${COMPOSE_FILE}.bak
+export MORPHIK_API_PORT="${API_PORT:-8000}"
 
 # 5.5. Ask about UI installation
 echo ""
@@ -439,7 +441,7 @@ fi
 
 # 6. Start the application
 print_info "Starting the Morphik stack... This may take a few minutes for the first run."
-docker compose -f "$COMPOSE_FILE" $UI_PROFILE up -d
+docker compose -f "$COMPOSE_FILE" $UI_PROFILE up -d --remove-orphans
 
 print_success "🚀 Morphik has been started!"
 print_info "📝 Check the logs for status - it can take a few minutes to fully load"
@@ -464,15 +466,15 @@ fi
 echo ""
 print_info "📋 Management commands:"
 print_info "   View logs:    docker compose -f $COMPOSE_FILE $UI_PROFILE logs -f"
-print_info "   Stop services: ./stop-morphik.sh   # runs docker compose down --volumes --remove-orphans"
+print_info "   Stop services: ./stop-morphik.sh   # preserves PostgreSQL and other named volumes"
 print_info "   Restart:      ./start-morphik.sh"
 print_info "   Pin version:  ./start-morphik.sh --version 2025-02-01"
 print_info "   List versions: docker image ls ghcr.io/morphik-org/morphik-core"
 
 # Create convenience startup script
 cat > start-morphik.sh << 'EOF'
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Purpose: Production startup script for Morphik
 # Automatically updates port mapping from morphik.toml and includes UI if installed
@@ -491,6 +493,10 @@ print_warning() {
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version)
+            if [ "$#" -lt 2 ]; then
+                echo "--version requires a tag" >&2
+                exit 2
+            fi
             export MORPHIK_VERSION="$2"
             shift 2
             ;;
@@ -505,7 +511,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Load MORPHIK_VERSION from .env if not set via flag
-if [ -z "$MORPHIK_VERSION" ] && [ -f ".env" ]; then
+if [ -z "${MORPHIK_VERSION:-}" ] && [ -f ".env" ]; then
     MORPHIK_VERSION=$(grep "^MORPHIK_VERSION=" .env 2>/dev/null | tail -n1 | cut -d= -f2-)
 fi
 export MORPHIK_VERSION="${MORPHIK_VERSION:-latest}"
@@ -513,13 +519,7 @@ export MORPHIK_VERSION="${MORPHIK_VERSION:-latest}"
 print_info "Using Morphik version: ${MORPHIK_VERSION}"
 
 API_PORT=$(awk '/^\[api\]/{flag=1; next} /^\[/{flag=0} flag && /^port[[:space:]]*=/ {gsub(/^port[[:space:]]*=[[:space:]]*/, ""); print; exit}' morphik.toml 2>/dev/null || echo "8000")
-CURRENT_PORT=$(grep -oE '"[0-9]+:[0-9]+"' docker-compose.run.yml | head -1 | cut -d: -f1 | tr -d '"')
-
-if [ "$CURRENT_PORT" != "$API_PORT" ]; then
-    echo "Updating port mapping from $CURRENT_PORT to $API_PORT..."
-    sed -i.bak "s|\"${CURRENT_PORT}:${CURRENT_PORT}\"|\"${API_PORT}:${API_PORT}\"|g" docker-compose.run.yml
-    rm -f docker-compose.run.yml.bak
-fi
+export MORPHIK_API_PORT="${API_PORT:-8000}"
 
 # Check multimodal embeddings configuration
 COLPALI_ENABLED=$(awk '/^\[morphik\]/{flag=1; next} /^\[/{flag=0} flag && /^enable_colpali[[:space:]]*=/ {gsub(/^enable_colpali[[:space:]]*=[[:space:]]*/, ""); print; exit}' morphik.toml 2>/dev/null || echo "true")
@@ -534,10 +534,10 @@ if [ -f ".env" ] && grep -q "UI_INSTALLED=true" .env; then
     UI_PROFILE="--profile ui"
 fi
 
-docker compose -f docker-compose.run.yml $UI_PROFILE up -d
-echo "🚀 Morphik ${MORPHIK_VERSION} is running on http://localhost:${API_PORT}"
-echo "   Health: http://localhost:${API_PORT}/health"
-echo "   Docs:   http://localhost:${API_PORT}/docs"
+docker compose -f docker-compose.run.yml $UI_PROFILE up -d --remove-orphans
+echo "🚀 Morphik ${MORPHIK_VERSION} is running on http://localhost:${MORPHIK_API_PORT}"
+echo "   Health: http://localhost:${MORPHIK_API_PORT}/health"
+echo "   Docs:   http://localhost:${MORPHIK_API_PORT}/docs"
 if [ -n "$UI_PROFILE" ]; then
     echo ""
     echo "🎨 Admin UI: http://localhost:3003"
@@ -546,8 +546,8 @@ EOF
 chmod +x start-morphik.sh
 
 cat > stop-morphik.sh << 'EOF'
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 COMPOSE_FILE="docker-compose.run.yml"
 
@@ -556,22 +556,10 @@ if [ ! -f "$COMPOSE_FILE" ]; then
     exit 1
 fi
 
-PROFILE_FLAGS=()
-if [ -f ".env" ] && grep -q "^COMPOSE_PROFILES=" .env; then
-    PROFILES=$(grep "^COMPOSE_PROFILES=" .env | tail -n1 | cut -d= -f2-)
-    IFS=',' read -r -a PROFILE_ARRAY <<< "$PROFILES"
-    for profile in "${PROFILE_ARRAY[@]}"; do
-        profile=$(echo "$profile" | xargs)
-        if [ -n "$profile" ]; then
-            PROFILE_FLAGS+=("--profile" "$profile")
-        fi
-    done
-elif [ -f ".env" ] && grep -q "UI_INSTALLED=true" .env; then
-    PROFILE_FLAGS+=("--profile" "ui")
-fi
-
-docker compose -f "$COMPOSE_FILE" "${PROFILE_FLAGS[@]}" down --volumes --remove-orphans
-echo "🛑 Morphik services stopped. Containers, networks, and anonymous volumes removed."
+# Activate every profile so optional UI and Ollama containers are stopped too.
+# A routine stop must preserve PostgreSQL and all other named volumes.
+docker compose -f "$COMPOSE_FILE" --profile "*" down --remove-orphans
+echo "🛑 Morphik services stopped. Persistent named volumes were preserved."
 EOF
 chmod +x stop-morphik.sh
 

--- a/scripts/test_postgres_persistence.sh
+++ b/scripts/test_postgres_persistence.sh
@@ -96,12 +96,29 @@ test "$volume_before" = "postgres_data"
 "${compose[@]}" up -d postgres
 wait_for_postgres
 
-persisted=$("${compose[@]}" exec -T postgres psql -At -v ON_ERROR_STOP=1 -U morphik -d morphik -c \
-    "SELECT external_id || '|' || doc_metadata->>'project' || '|' || doc_metadata->>'work_item_id' FROM documents WHERE external_id = 'iqor-persistence-probe';")
+read_probe() {
+    "${compose[@]}" exec -T postgres psql -At -v ON_ERROR_STOP=1 -U morphik -d morphik -c \
+        "SELECT external_id || '|' || (doc_metadata->>'project') || '|' || (doc_metadata->>'work_item_id') FROM documents WHERE external_id = 'iqor-persistence-probe';"
+}
+
+persisted=$(read_probe)
 
 if [ "$persisted" != "iqor-persistence-probe|QA|47490" ]; then
     echo "Document record did not survive PostgreSQL container recreation: $persisted" >&2
     exit 1
 fi
 
-echo "PASS: document identity and metadata survived PostgreSQL container recreation."
+# Exercise the checked-in lifecycle script twice to prove stop is idempotent and
+# does not delete the project-scoped PostgreSQL volume.
+(cd "$REPO_DIR" && COMPOSE_PROJECT_NAME="$TEST_PROJECT" ./stop-morphik.sh)
+(cd "$REPO_DIR" && COMPOSE_PROJECT_NAME="$TEST_PROJECT" ./stop-morphik.sh)
+"${compose[@]}" up -d postgres
+wait_for_postgres
+
+persisted=$(read_probe)
+if [ "$persisted" != "iqor-persistence-probe|QA|47490" ]; then
+    echo "Document record did not survive stop/start: $persisted" >&2
+    exit 1
+fi
+
+echo "PASS: document identity and metadata survived container recreation and repeated stop/start."

--- a/scripts/test_postgres_persistence.sh
+++ b/scripts/test_postgres_persistence.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 COMPOSE_FILE="$REPO_DIR/docker-compose.run.yml"
 TEST_PROJECT="${MORPHIK_PERSISTENCE_TEST_PROJECT:-morphik-persistence-test-$$}"
+export MORPHIK_ENV_FILE="${MORPHIK_ENV_FILE:-/dev/null}"
 
 case "$TEST_PROJECT" in
     morphik-persistence-test-*) ;;

--- a/scripts/test_postgres_persistence.sh
+++ b/scripts/test_postgres_persistence.sh
@@ -4,16 +4,10 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 COMPOSE_FILE="$REPO_DIR/docker-compose.run.yml"
-TEST_PROJECT="${MORPHIK_PERSISTENCE_TEST_PROJECT:-morphik-persistence-test-$$}"
+TEST_PROJECT="morphik-persistence-test-$$-${RANDOM}"
+TEST_VOLUME="${TEST_PROJECT}_postgres_data"
+TEST_NETWORK="${TEST_PROJECT}_morphik-network"
 export MORPHIK_ENV_FILE="${MORPHIK_ENV_FILE:-/dev/null}"
-
-case "$TEST_PROJECT" in
-    morphik-persistence-test-*) ;;
-    *)
-        echo "Test project name must start with morphik-persistence-test-." >&2
-        exit 2
-        ;;
-esac
 
 if ! command -v docker >/dev/null 2>&1; then
     echo "Docker is required." >&2
@@ -22,6 +16,13 @@ fi
 if ! docker info >/dev/null 2>&1; then
     echo "Docker is installed, but the daemon is not running." >&2
     exit 1
+fi
+
+if docker volume inspect "$TEST_VOLUME" >/dev/null 2>&1 || \
+    docker network inspect "$TEST_NETWORK" >/dev/null 2>&1 || \
+    docker ps -aq --filter "label=com.docker.compose.project=$TEST_PROJECT" | grep -q .; then
+    echo "Refusing to reuse existing Docker resources for test project $TEST_PROJECT." >&2
+    exit 2
 fi
 
 compose=(docker compose --project-name "$TEST_PROJECT" --project-directory "$REPO_DIR" -f "$COMPOSE_FILE")
@@ -46,7 +47,6 @@ wait_for_postgres() {
     return 1
 }
 
-cleanup
 "${compose[@]}" up -d postgres
 wait_for_postgres
 

--- a/scripts/test_postgres_persistence.sh
+++ b/scripts/test_postgres_persistence.sh
@@ -31,7 +31,9 @@ cleanup() {
     # This project name is unique to the test. Removing its volumes cannot touch a deployment.
     "${compose[@]}" --profile "*" down --volumes --remove-orphans >/dev/null 2>&1 || true
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 wait_for_postgres() {
     local attempts=30

--- a/scripts/test_postgres_persistence.sh
+++ b/scripts/test_postgres_persistence.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+COMPOSE_FILE="$REPO_DIR/docker-compose.run.yml"
+TEST_PROJECT="${MORPHIK_PERSISTENCE_TEST_PROJECT:-morphik-persistence-test-$$}"
+
+case "$TEST_PROJECT" in
+    morphik-persistence-test-*) ;;
+    *)
+        echo "Test project name must start with morphik-persistence-test-." >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required." >&2
+    exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker is installed, but the daemon is not running." >&2
+    exit 1
+fi
+
+compose=(docker compose --project-name "$TEST_PROJECT" --project-directory "$REPO_DIR" -f "$COMPOSE_FILE")
+
+cleanup() {
+    # This project name is unique to the test. Removing its volumes cannot touch a deployment.
+    "${compose[@]}" --profile "*" down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+wait_for_postgres() {
+    local attempts=30
+    while (( attempts > 0 )); do
+        if "${compose[@]}" exec -T postgres pg_isready -U morphik -d morphik >/dev/null 2>&1; then
+            return 0
+        fi
+        attempts=$((attempts - 1))
+        sleep 2
+    done
+    echo "PostgreSQL did not become ready." >&2
+    "${compose[@]}" logs postgres >&2 || true
+    return 1
+}
+
+cleanup
+"${compose[@]}" up -d postgres
+wait_for_postgres
+
+"${compose[@]}" exec -T postgres psql -v ON_ERROR_STOP=1 -U morphik -d morphik <<'SQL'
+CREATE TABLE documents (
+    external_id TEXT PRIMARY KEY,
+    content_type TEXT,
+    filename TEXT,
+    doc_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata_types JSONB NOT NULL DEFAULT '{}'::jsonb,
+    storage_info JSONB NOT NULL DEFAULT '{}'::jsonb,
+    system_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    additional_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    chunk_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    owner_id TEXT,
+    app_id TEXT,
+    folder_name TEXT,
+    folder_path TEXT,
+    folder_id TEXT,
+    end_user_id TEXT
+);
+INSERT INTO documents (
+    external_id,
+    content_type,
+    filename,
+    doc_metadata,
+    metadata_types,
+    system_metadata,
+    owner_id,
+    app_id
+) VALUES (
+    'iqor-persistence-probe',
+    'text/plain',
+    '47490.txt',
+    '{"project":"QA","work_item_type":"Product Backlog Item","work_item_id":"47490"}'::jsonb,
+    '{"project":"string","work_item_type":"string","work_item_id":"string"}'::jsonb,
+    '{"status":"completed"}'::jsonb,
+    'iqor-test',
+    'iqor-test'
+);
+SQL
+
+volume_before=$("${compose[@]}" config --volumes | awk '$0 == "postgres_data" { print; exit }')
+test "$volume_before" = "postgres_data"
+
+# Recreate only the PostgreSQL container. Docker Compose must reattach the same named volume.
+"${compose[@]}" rm --stop --force postgres
+"${compose[@]}" up -d postgres
+wait_for_postgres
+
+persisted=$("${compose[@]}" exec -T postgres psql -At -v ON_ERROR_STOP=1 -U morphik -d morphik -c \
+    "SELECT external_id || '|' || doc_metadata->>'project' || '|' || doc_metadata->>'work_item_id' FROM documents WHERE external_id = 'iqor-persistence-probe';")
+
+if [ "$persisted" != "iqor-persistence-probe|QA|47490" ]; then
+    echo "Document record did not survive PostgreSQL container recreation: $persisted" >&2
+    exit 1
+fi
+
+echo "PASS: document identity and metadata survived PostgreSQL container recreation."

--- a/scripts/verify_iqor_retrieval.sh
+++ b/scripts/verify_iqor_retrieval.sh
@@ -12,7 +12,9 @@ IQOR_TYPE_FIELD="${IQOR_TYPE_FIELD:-work_item_type}"
 IQOR_ID_FIELD="${IQOR_ID_FIELD:-work_item_id}"
 IQOR_CANDIDATE_K="${IQOR_CANDIDATE_K:-50}"
 IQOR_USE_COLPALI_JSON="${IQOR_USE_COLPALI_JSON:-false}"
-IQOR_RESPONSE_FILE="${IQOR_RESPONSE_FILE:-iqor-retrieval-response.json}"
+if [ -z "${IQOR_RESPONSE_FILE:-}" ]; then
+    IQOR_RESPONSE_FILE=$(mktemp "${TMPDIR:-/tmp}/iqor-retrieval-response.XXXXXX")
+fi
 
 for command in curl jq; do
     if ! command -v "$command" >/dev/null 2>&1; then

--- a/scripts/verify_iqor_retrieval.sh
+++ b/scripts/verify_iqor_retrieval.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${IQOR_QUERY:?Set IQOR_QUERY to the retrieval text for work item 47490}"
+
+MORPHIK_BASE_URL="${MORPHIK_BASE_URL:-http://localhost:8000}"
+IQOR_PROJECT="${IQOR_PROJECT:-QA}"
+IQOR_BACKLOG_TYPE="${IQOR_BACKLOG_TYPE:-Product Backlog Item}"
+IQOR_WORK_ITEM_ID_JSON="${IQOR_WORK_ITEM_ID_JSON:-47490}"
+IQOR_PROJECT_FIELD="${IQOR_PROJECT_FIELD:-project}"
+IQOR_TYPE_FIELD="${IQOR_TYPE_FIELD:-work_item_type}"
+IQOR_ID_FIELD="${IQOR_ID_FIELD:-work_item_id}"
+IQOR_CANDIDATE_K="${IQOR_CANDIDATE_K:-50}"
+IQOR_USE_COLPALI_JSON="${IQOR_USE_COLPALI_JSON:-false}"
+IQOR_RESPONSE_FILE="${IQOR_RESPONSE_FILE:-iqor-retrieval-response.json}"
+
+for command in curl jq; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "$command is required." >&2
+        exit 1
+    fi
+done
+
+if ! jq -en --argjson value "$IQOR_WORK_ITEM_ID_JSON" '$value' >/dev/null; then
+    echo "IQOR_WORK_ITEM_ID_JSON must be valid JSON, for example 47490 or \"47490\"." >&2
+    exit 2
+fi
+if ! jq -en --argjson value "$IQOR_USE_COLPALI_JSON" '$value | type == "boolean"' | grep -q true; then
+    echo "IQOR_USE_COLPALI_JSON must be true or false." >&2
+    exit 2
+fi
+
+curl_args=(
+    --silent
+    --show-error
+    --output "$IQOR_RESPONSE_FILE"
+    --write-out "%{http_code}"
+    --header "Content-Type: application/json"
+)
+if [ -n "${MORPHIK_AUTH_TOKEN:-}" ]; then
+    curl_args+=(--header "Authorization: Bearer ${MORPHIK_AUTH_TOKEN}")
+fi
+
+http_status=$(
+    jq -n \
+        --arg query "$IQOR_QUERY" \
+        --arg project "$IQOR_PROJECT" \
+        --arg backlog_type "$IQOR_BACKLOG_TYPE" \
+        --arg project_field "$IQOR_PROJECT_FIELD" \
+        --arg type_field "$IQOR_TYPE_FIELD" \
+        --arg id_field "$IQOR_ID_FIELD" \
+        --argjson current_id "$IQOR_WORK_ITEM_ID_JSON" \
+        --argjson candidate_k "$IQOR_CANDIDATE_K" \
+        --argjson use_colpali "$IQOR_USE_COLPALI_JSON" \
+        '{
+            query: $query,
+            k: $candidate_k,
+            min_score: 0.0,
+            use_colpali: $use_colpali,
+            output_format: "text",
+            filters: {
+                "$and": [
+                    {($project_field): {"$eq": $project}},
+                    {($type_field): {"$eq": $backlog_type}},
+                    {($id_field): {"$ne": $current_id}}
+                ]
+            }
+        }' |
+        curl "${curl_args[@]}" --data-binary @- "${MORPHIK_BASE_URL%/}/retrieve/chunks"
+)
+
+case "$http_status" in
+    2??) ;;
+    *)
+        echo "Morphik returned HTTP $http_status. Response saved to $IQOR_RESPONSE_FILE." >&2
+        jq . "$IQOR_RESPONSE_FILE" >&2 2>/dev/null || sed -n '1,120p' "$IQOR_RESPONSE_FILE" >&2
+        exit 1
+        ;;
+esac
+
+if ! jq -e \
+    --arg project "$IQOR_PROJECT" \
+    --arg backlog_type "$IQOR_BACKLOG_TYPE" \
+    --arg project_field "$IQOR_PROJECT_FIELD" \
+    --arg type_field "$IQOR_TYPE_FIELD" \
+    --arg id_field "$IQOR_ID_FIELD" \
+    --argjson current_id "$IQOR_WORK_ITEM_ID_JSON" \
+    'type == "array" and all(.[];
+        (.metadata[$project_field] == $project) and
+        (.metadata[$type_field] == $backlog_type) and
+        (.metadata[$id_field] != $current_id) and
+        (.document_id | type == "string") and
+        (.chunk_number | type == "number") and
+        (.score | type == "number"))' \
+    "$IQOR_RESPONSE_FILE" >/dev/null; then
+    echo "Response violated the metadata, exclusion, score, or source-ID contract." >&2
+    exit 1
+fi
+
+distinct_count=$(jq \
+    --arg id_field "$IQOR_ID_FIELD" \
+    '[.[].metadata[$id_field]] | unique | length' \
+    "$IQOR_RESPONSE_FILE")
+
+if (( distinct_count < 5 )); then
+    echo "Expected at least five distinct backlog items, got $distinct_count. Raw response: $IQOR_RESPONSE_FILE" >&2
+    exit 1
+fi
+
+jq \
+    --arg id_field "$IQOR_ID_FIELD" \
+    'group_by(.metadata[$id_field])
+    | map(max_by(.score))
+    | sort_by(-.score)
+    | .[:5]
+    | map(. + {source_id: (.document_id + ":" + (.chunk_number | tostring))})' \
+    "$IQOR_RESPONSE_FILE"
+
+echo "PASS: response contains at least five distinct QA backlog items and excludes work item 47490." >&2
+echo "Raw response saved to $IQOR_RESPONSE_FILE." >&2

--- a/scripts/verify_iqor_retrieval.sh
+++ b/scripts/verify_iqor_retrieval.sh
@@ -12,6 +12,17 @@ IQOR_TYPE_FIELD="${IQOR_TYPE_FIELD:-work_item_type}"
 IQOR_ID_FIELD="${IQOR_ID_FIELD:-work_item_id}"
 IQOR_CANDIDATE_K="${IQOR_CANDIDATE_K:-50}"
 IQOR_USE_COLPALI_JSON="${IQOR_USE_COLPALI_JSON:-false}"
+AUTH_HEADER_FILE=""
+
+cleanup_auth_header() {
+    if [ -n "$AUTH_HEADER_FILE" ]; then
+        rm -f -- "$AUTH_HEADER_FILE"
+    fi
+}
+trap cleanup_auth_header EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 if [ -z "${IQOR_RESPONSE_FILE:-}" ]; then
     IQOR_RESPONSE_FILE=$(mktemp "${TMPDIR:-/tmp}/iqor-retrieval-response.XXXXXX")
 fi
@@ -40,7 +51,10 @@ curl_args=(
     --header "Content-Type: application/json"
 )
 if [ -n "${MORPHIK_AUTH_TOKEN:-}" ]; then
-    curl_args+=(--header "Authorization: Bearer ${MORPHIK_AUTH_TOKEN}")
+    AUTH_HEADER_FILE=$(mktemp "${TMPDIR:-/tmp}/iqor-auth-header.XXXXXX")
+    chmod 600 "$AUTH_HEADER_FILE"
+    printf 'Authorization: Bearer %s\n' "$MORPHIK_AUTH_TOKEN" > "$AUTH_HEADER_FILE"
+    curl_args+=(--header "@$AUTH_HEADER_FILE")
 fi
 
 http_status=$(

--- a/scripts/verify_iqor_retrieval.sh
+++ b/scripts/verify_iqor_retrieval.sh
@@ -90,10 +90,12 @@ if ! jq -e \
     'type == "array" and all(.[];
         (.metadata[$project_field] == $project) and
         (.metadata[$type_field] == $backlog_type) and
+        ((.metadata[$id_field] | type) == ($current_id | type)) and
         (.metadata[$id_field] != $current_id) and
         (.document_id | type == "string") and
         (.chunk_number | type == "number") and
-        (.score | type == "number"))' \
+        (.score | type == "number") and
+        (.score >= 0.0))' \
     "$IQOR_RESPONSE_FILE" >/dev/null; then
     echo "Response violated the metadata, exclusion, score, or source-ID contract." >&2
     exit 1

--- a/start-morphik.sh
+++ b/start-morphik.sh
@@ -42,7 +42,7 @@ done
 
 # Load MORPHIK_VERSION from .env if not set via flag
 if [ -z "${MORPHIK_VERSION:-}" ] && [ -f ".env" ]; then
-    MORPHIK_VERSION=$(grep "^MORPHIK_VERSION=" .env 2>/dev/null | tail -n1 | cut -d= -f2-)
+    MORPHIK_VERSION=$(sed -n 's/^MORPHIK_VERSION=//p' .env | tail -n1)
 fi
 export MORPHIK_VERSION="${MORPHIK_VERSION:-latest}"
 
@@ -58,22 +58,13 @@ fi
 API_PORT=$(awk '/^\[api\]/{flag=1; next} /^\[/{flag=0} flag && /^port[[:space:]]*=/ {gsub(/^port[[:space:]]*=[[:space:]]*/, ""); print; exit}' morphik.toml 2>/dev/null || true)
 export MORPHIK_API_PORT="${API_PORT:-8000}"
 
-PROFILE_FLAGS=()
-if [ -f ".env" ] && grep -q "^COMPOSE_PROFILES=" .env; then
-    PROFILES=$(grep "^COMPOSE_PROFILES=" .env | tail -n1 | cut -d= -f2-)
-    IFS=',' read -r -a PROFILE_ARRAY <<< "$PROFILES"
-    for profile in "${PROFILE_ARRAY[@]}"; do
-        profile=$(echo "$profile" | xargs)
-        if [ -n "$profile" ]; then
-            PROFILE_FLAGS+=("--profile" "$profile")
-        fi
-    done
-elif [ -f ".env" ] && grep -q "^UI_INSTALLED=true" .env; then
-    PROFILE_FLAGS+=("--profile" "ui")
+UI_PROFILE=""
+if [ -f ".env" ] && grep -q "^UI_INSTALLED=true" .env; then
+    UI_PROFILE="--profile ui"
 fi
 
 print_info "Starting Morphik with port ${MORPHIK_API_PORT}..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_FLAGS[@]}" up -d --remove-orphans
+docker compose -f "$COMPOSE_FILE" $UI_PROFILE up -d --remove-orphans
 
 print_success "🚀 Morphik is running!"
 print_info "🌐 API endpoints:"

--- a/start-morphik.sh
+++ b/start-morphik.sh
@@ -1,10 +1,9 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Purpose: Production startup script for Morphik (created by install_docker.sh)
-# This script reads the port from morphik.toml and dynamically updates docker-compose.run.yml
-# port mapping if it has changed. This allows users to change ports in morphik.toml
-# without manually editing docker-compose.run.yml after installation.
+# This script reads the port from morphik.toml and passes it to Docker Compose.
+# It is safe to run repeatedly and never rewrites the compose file.
 # Usage: ./start-morphik.sh [--version <tag>]
 
 # Color output functions
@@ -16,10 +15,18 @@ print_success() {
     echo -e "\033[32m✅ $1\033[0m"
 }
 
+print_error() {
+    echo -e "\033[31m❌ $1\033[0m" >&2
+}
+
 # Parse --version flag (overrides .env)
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version)
+            if [ "$#" -lt 2 ]; then
+                print_error "--version requires a tag"
+                exit 2
+            fi
             export MORPHIK_VERSION="$2"
             shift 2
             ;;
@@ -34,35 +41,42 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Load MORPHIK_VERSION from .env if not set via flag
-if [ -z "$MORPHIK_VERSION" ] && [ -f ".env" ]; then
+if [ -z "${MORPHIK_VERSION:-}" ] && [ -f ".env" ]; then
     MORPHIK_VERSION=$(grep "^MORPHIK_VERSION=" .env 2>/dev/null | tail -n1 | cut -d= -f2-)
 fi
 export MORPHIK_VERSION="${MORPHIK_VERSION:-latest}"
 
 print_info "Using Morphik version: ${MORPHIK_VERSION}"
 
-# Read port from morphik.toml
-API_PORT=$(awk '/^\[api\]/{flag=1; next} /^\[/{flag=0} flag && /^port[[:space:]]*=/ {gsub(/^port[[:space:]]*=[[:space:]]*/, ""); print; exit}' morphik.toml 2>/dev/null || echo "8000")
-
-# Check if docker-compose.run.yml exists
-if [ ! -f "docker-compose.run.yml" ]; then
+COMPOSE_FILE="docker-compose.run.yml"
+if [ ! -f "$COMPOSE_FILE" ]; then
     print_error "docker-compose.run.yml not found. Please run the install script first."
     exit 1
 fi
 
-# Create temporary compose file with updated port
-cp docker-compose.run.yml docker-compose.run.yml.tmp
-sed -i.bak "s|\"8000:8000\"|\"${API_PORT}:${API_PORT}\"|g" docker-compose.run.yml.tmp
-rm -f docker-compose.run.yml.tmp.bak
+# Read the API port and use 8000 when the setting is absent.
+API_PORT=$(awk '/^\[api\]/{flag=1; next} /^\[/{flag=0} flag && /^port[[:space:]]*=/ {gsub(/^port[[:space:]]*=[[:space:]]*/, ""); print; exit}' morphik.toml 2>/dev/null || true)
+export MORPHIK_API_PORT="${API_PORT:-8000}"
 
-print_info "Starting Morphik with port ${API_PORT}..."
-docker compose -f docker-compose.run.yml.tmp up -d
+PROFILE_FLAGS=()
+if [ -f ".env" ] && grep -q "^COMPOSE_PROFILES=" .env; then
+    PROFILES=$(grep "^COMPOSE_PROFILES=" .env | tail -n1 | cut -d= -f2-)
+    IFS=',' read -r -a PROFILE_ARRAY <<< "$PROFILES"
+    for profile in "${PROFILE_ARRAY[@]}"; do
+        profile=$(echo "$profile" | xargs)
+        if [ -n "$profile" ]; then
+            PROFILE_FLAGS+=("--profile" "$profile")
+        fi
+    done
+elif [ -f ".env" ] && grep -q "^UI_INSTALLED=true" .env; then
+    PROFILE_FLAGS+=("--profile" "ui")
+fi
+
+print_info "Starting Morphik with port ${MORPHIK_API_PORT}..."
+docker compose -f "$COMPOSE_FILE" "${PROFILE_FLAGS[@]}" up -d --remove-orphans
 
 print_success "🚀 Morphik is running!"
 print_info "🌐 API endpoints:"
-print_info "   Health check: http://localhost:${API_PORT}/health"
-print_info "   API docs:     http://localhost:${API_PORT}/docs"
-print_info "   Main API:     http://localhost:${API_PORT}"
-
-# Cleanup temp file
-rm -f docker-compose.run.yml.tmp
+print_info "   Health check: http://localhost:${MORPHIK_API_PORT}/health"
+print_info "   API docs:     http://localhost:${MORPHIK_API_PORT}/docs"
+print_info "   Main API:     http://localhost:${MORPHIK_API_PORT}"

--- a/stop-morphik.sh
+++ b/stop-morphik.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.run.yml"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "docker-compose.run.yml not found. Run this script from the Morphik install directory." >&2
+    exit 1
+fi
+
+# Activate every profile so `down` also removes optional UI and Ollama containers.
+# Do not add --volumes here. PostgreSQL, Redis, model, and UI data must survive a
+# routine stop/start cycle.
+docker compose -f "$COMPOSE_FILE" --profile "*" down --remove-orphans
+echo "Morphik services stopped. Persistent named volumes were preserved."


### PR DESCRIPTION
Preserves PostgreSQL and other named volumes during normal stop, stops every Compose profile, removes fixed production container names and the host PostgreSQL port, makes API-port handling repeatable, and uses `.env` syntax supported across Docker Compose V2.

Enforces `min_score`, adds lifecycle, update, retrieval-contract, no-egress, and Docker recreation tests, plus scripts that prove PostgreSQL persistence and validate iQor work item 47490 responses.

Follow-up review fixes cover startup fallback behavior, collision-safe test projects, work-item ID and score validation, historical-log egress, bearer-token process exposure, signal cleanup, temporary customer-response storage, and consistent production Docker documentation.

Verification: 28 targeted tests passed, including PostgreSQL recreation and repeated stop/start on Docker Engine 27.4.0, Compose rendering and pre-commit passed, and the final fresh Codex review returned no findings.